### PR TITLE
weakening http method constraint to allow PUT or POST for uploads.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,7 @@
 
+Version 2.0.5
+ * Fixed bug: prevent leaking of file descriptor on a timeout.
+
 Version 2.0.4
  * Fixed bug: location configuration of upload_set_form_field and upload_pass_form_field
    was not inheritable from server configuration.

--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,10 @@ Version 2.0.4
    on request for file content. When no calculation is requested, additional memory
    and CPU are not used. Calculation could be requested via specifying variables
    $upload_file_md5, $upload_file_md5_uc, $upload_file_sha1 and $upload_file_sha1_uc.
+ * Fixed bug: missing CRLF at the end of resulting body.
+ * Added feature: limiting file size and resulting body size via upload_max_file_size
+   and upload_max_output_body_len.
+ * Change: optimized out some unnecessary memory allocations and zeroeing.
 
 Version 2.0.3
  * upload_store directive was not able to receive more than one argument.

--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,7 @@ Version 2.0.3
  * In case of any errors at the last chunk of request body only 500 Internal Server Error
    was generated intead of 400 Bad Request and 503 Service Unavailable.
  * Fixed copyrights for temporary file name generation code
+ * Fixed compilation issue on 0.6.32. Thanks to Tomas Pollak.
 
 Version 2.0.2
  * Fixed crash in logging filename while aborting upload

--- a/Changelog
+++ b/Changelog
@@ -3,10 +3,7 @@ Version 2.0.4
  * Fixed bug: location configuration of upload_set_form_field and upload_pass_form_field
    was not inheritable from server configuration.
  * Added feature: directive upload_aggregate_form_field to pass aggragate properties
-   of a file like file size, MD5 and SHA1 sums to backend. MD5 and SHA1 sums are calculated
-   on request for file content. When no calculation is requested, additional memory
-   and CPU are not used. Calculation could be requested via specifying variables
-   $upload_file_md5, $upload_file_md5_uc, $upload_file_sha1 and $upload_file_sha1_uc.
+   of a file like file size, MD5 and SHA1 sums to backend.
  * Fixed bug: missing CRLF at the end of resulting body.
  * Change: optimized out some unnecessary memory allocations and zeroeing.
 

--- a/Changelog
+++ b/Changelog
@@ -8,6 +8,8 @@ Version 2.0.3
    was generated intead of 400 Bad Request and 503 Service Unavailable.
  * Fixed copyrights for temporary file name generation code
  * Fixed compilation issue on 0.6.32. Thanks to Tomas Pollak.
+ * Added directive upload_pass_form_field to specify fields
+   to pass to backend. Fixes security hole found by Brian Moran.
 
 Version 2.0.2
  * Fixed crash in logging filename while aborting upload

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,13 @@
 
+Version 2.1.0
+ * Added feature: upload filters, unzip and discarding filter
+ * Added feature: guessing content type using file extensions
+
+Version 2.0.6
+ * Fixed bug: zero variables in aggregate field name caused allocation
+   of random amount of memory. Thanks to Dmitry Dedukhin.
+ * Fixed bug: Prevent generation of a field in case of empty field name
+
 Version 2.0.5
  * Fixed bug: prevent leaking of file descriptor on a timeout.
 

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,10 @@
 
+Version 2.1.1
+ * Change: file size and output body size restrictions
+ * Added feature: directive upload_pass_args enables forwarding
+   of request arguments to a backend. Thanks to Todd Fisher.
+ * Added feature: guessing of file's content type via file extension
+
 Version 2.1.0
  * Added feature: upload filters, unzip and discarding filter
  * Added feature: guessing content type using file extensions

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,13 @@
 
+Version 2.0.4
+ * Fixed bug: location configuration of upload_set_form_field and upload_pass_form_field
+   was not inheritable from server configuration.
+ * Added feature: directive upload_aggregate_form_field to pass aggragate properties
+   of a file like file size, MD5 and SHA1 sums to backend. MD5 and SHA1 sums are calculated
+   on request for file content. When no calculation is requested, additional memory
+   and CPU are not used. Calculation could be requested via specifying variables
+   $upload_file_md5, $upload_file_md5_uc, $upload_file_sha1 and $upload_file_sha1_uc.
+
 Version 2.0.3
  * upload_store directive was not able to receive more than one argument.
    As a result no hashed dirs for file uploads were possible.

--- a/Changelog
+++ b/Changelog
@@ -5,7 +5,7 @@ Version 2.0.4
  * Added feature: directive upload_aggregate_form_field to pass aggragate properties
    of a file like file size, MD5 and SHA1 sums to backend.
  * Fixed bug: missing CRLF at the end of resulting body.
- * Change: optimized out some unnecessary memory allocations and zeroeing.
+ * Change: optimized out some unnecessary memory allocations and zeroing.
 
 Version 2.0.3
  * upload_store directive was not able to receive more than one argument.

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,13 @@
 
+Version 2.0.3
+ * upload_store directive was not able to receive more than one argument.
+   As a result no hashed dirs for file uploads were possible.
+ * upload_store_access directive did not work completely.
+   Thanks to Brian Moran.
+ * In case of any errors at the last chunk of request body only 500 Internal Server Error
+   was generated intead of 400 Bad Request and 503 Service Unavailable.
+ * Fixed copyrights for temporary file name generation code
+
 Version 2.0.2
  * Fixed crash in logging filename while aborting upload
  * Added feasible debug logging

--- a/Changelog
+++ b/Changelog
@@ -8,8 +8,6 @@ Version 2.0.4
    and CPU are not used. Calculation could be requested via specifying variables
    $upload_file_md5, $upload_file_md5_uc, $upload_file_sha1 and $upload_file_sha1_uc.
  * Fixed bug: missing CRLF at the end of resulting body.
- * Added feature: limiting file size and resulting body size via upload_max_file_size
-   and upload_max_output_body_len.
  * Change: optimized out some unnecessary memory allocations and zeroeing.
 
 Version 2.0.3

--- a/Changelog
+++ b/Changelog
@@ -3,7 +3,8 @@ Version 2.1.1
  * Change: file size and output body size restrictions
  * Added feature: directive upload_pass_args enables forwarding
    of request arguments to a backend. Thanks to Todd Fisher.
- * Added feature: guessing of file's content type via file extension
+ * Added feature: specifying list of void content types via
+ upload_void_content_types directive
 
 Version 2.1.0
  * Added feature: upload filters, unzip and discarding filter

--- a/Changelog
+++ b/Changelog
@@ -2,8 +2,8 @@
 Version 2.0.3
  * upload_store directive was not able to receive more than one argument.
    As a result no hashed dirs for file uploads were possible.
- * upload_store_access directive did not work completely.
-   Thanks to Brian Moran.
+ * upload_store_access directive did not work at all. Permissions were
+   defaulted to user:rw. Thanks to Brian Moran.
  * In case of any errors at the last chunk of request body only 500 Internal Server Error
    was generated intead of 400 Bad Request and 503 Service Unavailable.
  * Fixed copyrights for temporary file name generation code

--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-* Copyright (c) 2008, Valery Kholodkov
+* Copyright (c) 2006, 2008, Valery Kholodkov
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/README
+++ b/README
@@ -1,0 +1,10 @@
+
+Documentation for this module could be found under following URL:
+
+  * English:
+
+    http://www.grid.net.ru/nginx/upload.en.html
+
+  * Russian:
+
+    http://www.grid.net.ru/nginx/upload.ru.html

--- a/config
+++ b/config
@@ -1,5 +1,6 @@
 USE_MD5=YES
 USE_SHA1=YES
+USE_ZLIB=YES
 ngx_addon_name=ngx_http_upload_module
 HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module ngx_upload_unzip_filter_module ngx_upload_discard_filter_module"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c $ngx_addon_dir/ngx_upload_unzip_filter_module.c $ngx_addon_dir/ngx_upload_discard_filter_module.c"

--- a/config
+++ b/config
@@ -1,5 +1,6 @@
 USE_MD5=YES
 USE_SHA1=YES
 ngx_addon_name=ngx_http_upload_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c"
+HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module ngx_http_unzip_filter_module"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c $ngx_addon_dir/ngx_http_unzip_filter_module.c"
+HTTP_INCS="$HTTP_INCS $ngx_addon_dir"

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 USE_MD5=YES
 USE_SHA1=YES
 ngx_addon_name=ngx_http_upload_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module ngx_http_unzip_filter_module ngx_upload_discard_filter_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c $ngx_addon_dir/ngx_http_unzip_filter_module.c $ngx_addon_dir/ngx_upload_discard_filter_module.c"
+HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module ngx_upload_unzip_filter_module ngx_upload_discard_filter_module"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c $ngx_addon_dir/ngx_upload_unzip_filter_module.c $ngx_addon_dir/ngx_upload_discard_filter_module.c"
 HTTP_INCS="$HTTP_INCS $ngx_addon_dir"

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 USE_MD5=YES
 USE_SHA1=YES
 ngx_addon_name=ngx_http_upload_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module ngx_http_unzip_filter_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c $ngx_addon_dir/ngx_http_unzip_filter_module.c"
+HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module ngx_http_unzip_filter_module ngx_upload_discard_filter_module"
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c $ngx_addon_dir/ngx_http_unzip_filter_module.c $ngx_addon_dir/ngx_upload_discard_filter_module.c"
 HTTP_INCS="$HTTP_INCS $ngx_addon_dir"

--- a/config
+++ b/config
@@ -1,3 +1,5 @@
+USE_MD5=YES
+USE_SHA1=YES
 ngx_addon_name=ngx_http_upload_module
 HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c"

--- a/example-unzip.php
+++ b/example-unzip.php
@@ -1,0 +1,54 @@
+<?php
+$header_prefix = 'file';
+?>
+<html>
+<head>
+<title>Test upload</title>
+</head>
+<body>
+<?
+if ($_POST){
+    echo "<h2>Uploaded files:</h2>";
+
+    echo "<table border=\"2\" cellpadding=\"2\">";
+
+    echo "<tr><td>Archive path</td><td>File name</td><td>Location</td><td>Content type</td><td>MD5</td><td>Size</tr>";
+
+    $fdesc_keys = array_keys($_POST);
+
+    foreach($fdesc_keys as $fdesc_key) {
+        if(strpos($fdesc_key, $header_prefix) == 0 &&
+            strpos($fdesc_key, "_name") > 0) {
+            $key = substr($fdesc_key, 0, count($fdesc_key) - 6);
+
+            if (array_key_exists($key."_name", $_POST) && array_key_exists($key."_path",$_POST)) {
+                $archive_path = $_POST[$key."_archive_path"];
+                $tmp_name = $_POST[$key."_path"];
+                $name = $_POST[$key."_name"];
+                $content_type = $_POST[$key."_content_type"];
+                $md5 = $_POST[$key."_md5"];
+                $size = $_POST[$key."_size"];
+
+                echo "<tr><td>$archive_path</td><td>$name</td><td>$tmp_name</td><td>$content_type</td><td>$md5</td><td>$size</td>";
+            }
+        }
+	}
+
+    echo "</table>";
+
+}else{?>
+<h2>Select files to upload</h2>
+<form name="upload" method="POST" enctype="multipart/form-data" action="/upload">
+<input type="file" name="file1"><br>
+<input type="file" name="file2"><br>
+<input type="file" name="file3"><br>
+<input type="file" name="file4"><br>
+<input type="file" name="file5"><br>
+<input type="file" name="file6"><br>
+<input type="submit" name="submit" value="Upload">
+<input type="hidden" name="test" value="value">
+</form>
+<?}
+?>
+</body>
+</html>

--- a/example.php
+++ b/example.php
@@ -1,33 +1,37 @@
 <?php
 $header_prefix = 'file';
-$upload_dir = 'upload';
 $slots = 6;
-
-if ($_POST){
-	for ($i=0;$i<=$slots;$i++){
-		$key = $header_prefix.$i;
-		if (array_key_exists($key."_name", $_POST) && array_key_exists($key."_path",$_POST)) {
-			$tmp_name = $_POST[$key."_path"];
-			$name = $_POST[$key."_name"];
-			$newname = $upload_dir."/".$name;
-			if (rename($tmp_name, $newname)) {
-				echo "Moved to $upload_dir successfull<br/>\n";
-			} else {
-				echo "Failed to move file<br/>\n";
-			}
-		}else{
-			continue;
-		}
-	}
-}else{?>
-
+?>
 <html>
 <head>
 <title>Test upload</title>
 </head>
 <body>
+<?
+if ($_POST){
+    echo "<h2>Uploaded files:</h2>";
+    echo "<table border=\"2\" cellpadding=\"2\">";
+
+    echo "<tr><td>Name</td><td>Location</td><td>Content type</td><td>MD5</td><td>Size</tr>";
+
+	for ($i=1;$i<=$slots;$i++){
+		$key = $header_prefix.$i;
+		if (array_key_exists($key."_name", $_POST) && array_key_exists($key."_path",$_POST)) {
+			$tmp_name = $_POST[$key."_path"];
+			$name = $_POST[$key."_name"];
+			$content_type = $_POST[$key."_content_type"];
+			$md5 = $_POST[$key."_md5"];
+			$size = $_POST[$key."_size"];
+
+            echo "<tr><td>$name</td><td>$tmp_name</td><td>$content_type</td><td>$md5</td><td>$size</td>";
+		}
+	}
+
+    echo "</table>";
+
+}else{?>
 <h2>Select files to upload</h2>
-<form name="upload" method="POST" enctype="multipart/form-data" action="/doupload">
+<form name="upload" method="POST" enctype="multipart/form-data" action="/upload">
 <input type="file" name="file1"><br>
 <input type="file" name="file2"><br>
 <input type="file" name="file3"><br>
@@ -37,8 +41,7 @@ if ($_POST){
 <input type="submit" name="submit" value="Upload">
 <input type="hidden" name="test" value="value">
 </form>
-</body>
-</html>
-	
 <?}
 ?>
+</body>
+</html>

--- a/nginx-unzip.conf
+++ b/nginx-unzip.conf
@@ -1,0 +1,56 @@
+
+worker_processes  20;
+
+error_log  logs/error.log notice;
+
+working_directory /usr/local/nginx;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    server {
+        listen       80;
+        client_max_body_size 100m;
+
+        # Upload form should be submitted to this location
+        location /upload {
+            # Pass altered request body to this location
+            upload_pass   /test;
+
+            # Store files to this directory
+            # The directory is hashed, subdirectories 0 1 2 3 4 5 6 7 8 9 should exist
+            upload_store /tmp 1;
+            
+            # Allow uploaded files to be read only by user
+            upload_store_access user:r;
+
+            # Set specified fields in request body
+            upload_set_form_field "${upload_field_name}${upload_archive_elm}_name" $upload_file_name;
+            upload_set_form_field "${upload_field_name}${upload_archive_elm}_content_type" $upload_content_type;
+            upload_set_form_field "${upload_field_name}${upload_archive_elm}_path" $upload_tmp_path;
+            upload_set_form_field "${upload_field_name}${upload_archive_elm}_archive_path" $upload_archive_path;
+
+            # Inform backend about hash and size of a file
+            upload_aggregate_form_field "${upload_field_name}${upload_archive_elm}_md5" $upload_file_md5;
+            upload_aggregate_form_field "${upload_field_name}${upload_archive_elm}_size" $upload_file_size;
+
+            upload_pass_form_field "^submit$|^description$";
+
+            upload_cleanup 400-599;
+
+            upload_filter application/zip {
+                upload_unzip on;
+            }
+        }
+
+        # Pass altered request body to a backend
+        location /test {
+            proxy_pass   http://localhost:8080;
+        }
+    }
+}

--- a/nginx-unzip.conf
+++ b/nginx-unzip.conf
@@ -41,10 +41,14 @@ http {
 
             upload_pass_form_field "^submit$|^description$";
 
-            upload_cleanup 400-599;
+            upload_cleanup 404 500-505;
 
             upload_filter application/zip {
-                upload_unzip on;
+                upload_unzip;
+            }
+
+            upload_filter application/java-archive {
+                upload_unzip;
             }
         }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,7 +3,6 @@ worker_processes  20;
 
 error_log  logs/error.log notice;
 
-user root nobody;
 working_directory /usr/local/nginx;
 
 events {

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,15 +14,34 @@ http {
     default_type  application/octet-stream;
 
     server {
-        client_max_body_size 100m;
         listen       80;
-        server_name  localhost;
+        client_max_body_size 100m;
 
+        # Upload form should be submitted to this location
         location /upload {
+            # Pass altered request body to this location
             upload_pass   /test;
-            upload_store /tmp;
+
+            # Store files to this directory
+            # The directory is hashed, subdirectories 0 1 2 3 4 5 6 7 8 9 should exist
+            upload_store /tmp 1;
+            
+            # Allow uploaded files to be read only by user
+            upload_store_access user:r;
+
+            # Set specified fields in request body
+            upload_set_form_field "${upload_field_name}_name" $upload_file_name;
+            upload_set_form_field "${upload_field_name}_content_type" $upload_content_type;
+            upload_set_form_field "${upload_field_name}_path" $upload_tmp_path;
+
+            # Inform backend about hash and size of a file
+            upload_aggregate_form_field "${upload_field_name}_md5" $upload_file_md5;
+            upload_aggregate_form_field "${upload_field_name}_size" $upload_file_size;
+
+            upload_pass_form_field "^submit$|^description$";
         }
 
+        # Pass altered request body to a backend
         location /test {
             proxy_pass   http://localhost:8080;
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -39,6 +39,10 @@ http {
             upload_aggregate_form_field "${upload_field_name}_size" $upload_file_size;
 
             upload_pass_form_field "^submit$|^description$";
+
+            upload_filter "application/zip" {
+                unzip on;
+            }
         }
 
         # Pass altered request body to a backend

--- a/nginx.conf
+++ b/nginx.conf
@@ -39,10 +39,6 @@ http {
             upload_aggregate_form_field "${upload_field_name}_size" $upload_file_size;
 
             upload_pass_form_field "^submit$|^description$";
-
-            upload_filter "application/zip" {
-                unzip on;
-            }
         }
 
         # Pass altered request body to a backend

--- a/ngx_http_unzip_filter_module.c
+++ b/ngx_http_unzip_filter_module.c
@@ -14,10 +14,13 @@
 #define LOCAL_DATA_HEADER_SIGNATURE         0x04034b50
 #define ARCHIVE_EXTRA_DATA_SIGNATURE        0x08064b50
 #define CENTRAL_FILE_HEADER_SIGNATURE       0x02014b50
+#define DIGITAL_SIGNATURE_HEADER_SIGNATURE  0x05054b50
+#define END_OF_CENTRAL_DIR_SIGNATURE        0x06054b50
 #define SIGNATURE_LEN                       4 
 #define LOCAL_DATA_HEADER_LEN               30
 #define FILE_HEADER_LEN                     46
 #define DATA_DESCRIPTOR_LEN                 12
+#define END_OF_CENTRAL_DIR_LEN              18
 
 #define ZIP_METHOD_STORED                   0
 #define ZIP_METHOD_DEFLATED                 8
@@ -34,8 +37,22 @@
 #define EXTRACT_LONG(x) (uint32_t)(*(x) << 24 | *((x)+1) << 16 | *((x)+2) << 8 | *((x)+3))
 #endif
 
+struct ngx_unzip_ctx_s;
+
+typedef struct {
+    uint16_t method;
+    ngx_int_t (*start)(struct ngx_unzip_ctx_s*);
+    void (*finish)(struct ngx_unzip_ctx_s*);
+    void (*abort)(struct ngx_unzip_ctx_s*);
+    ngx_int_t (*process_chain)(struct ngx_unzip_ctx_s*, ngx_chain_t*);
+} ngx_unzip_decompression_method_t;
+
+#define ngx_unzip_decompression_method_null { 0xffff, NULL, NULL, NULL, NULL }
+
 typedef struct {
     ngx_bufs_t           bufs;
+    size_t               wbits;
+    size_t               max_file_name_len;
     unsigned int         recursive:1;
 } ngx_unzip_conf_t;
 
@@ -49,6 +66,7 @@ typedef enum {
     unzip_state_decryption_header,
     unzip_state_extra_data_record,
     unzip_state_file_header,
+    unzip_state_digital_sig_header,
     unzip_state_central_directory_end,
     unzip_state_finish
 } ngx_unzip_state_e;
@@ -67,6 +85,50 @@ typedef struct {
 } ngx_unzip_local_data_header_t;
 
 typedef struct {
+    uint16_t            version_made_by;
+    uint16_t            version_needed;
+    uint16_t            flags;
+    uint16_t            compression_method;
+    uint16_t            last_mod_time;
+    uint16_t            last_mod_date;
+    uint32_t            crc32;
+    size_t              compressed_size;
+    size_t              uncompressed_size;
+    size_t              file_name_len;
+    size_t              extra_field_len;
+    size_t              file_comment_len;
+    uint16_t            disk_number_start;
+    uint16_t            internal_file_attributes;
+    uint16_t            external_file_attributes;
+    off_t               relative_offset;
+} ngx_unzip_file_data_header_t;
+
+typedef struct {
+    size_t              data_size;
+} ngx_unzip_digital_signature_t;
+
+typedef struct {
+    uint16_t            version_made_by;
+    uint16_t            version_needed;
+    uint16_t            flags;
+    uint16_t            compression_method;
+    uint16_t            last_mod_time;
+    uint16_t            last_mod_date;
+    uint32_t            crc32;
+    size_t              compressed_size;
+    size_t              uncompressed_size;
+    size_t              file_name_len;
+    size_t              extra_field_len;
+    size_t              file_comment_len;
+    uint16_t            disk_number_start;
+    uint16_t            internal_file_attrs;
+    uint16_t            external_file_attrs;
+    off_t               relative_offset;
+} ngx_unzip_end_of_central_dir_t;
+
+typedef struct ngx_unzip_ctx_s {
+    struct ngx_unzip_ctx_s *parent;
+
     ngx_unzip_state_e   state;
     size_t              current_field_len;
     size_t              current_field_pos;
@@ -74,14 +136,14 @@ typedef struct {
     ngx_pool_t          *pool;
     ngx_log_t           *log;
 
-    u_char              buffer[512];
+    u_char              accumulator[512];
 
     u_char              *current_field;
     u_char              *current_field_ptr;
 
     uint16_t            version_needed;
     uint16_t            flags;
-    uint16_t            compression_method;
+    uint16_t            compression_method_number;
     uint16_t            last_mod_time;
     uint16_t            last_mod_date;
     uint32_t            crc32;
@@ -94,8 +156,12 @@ typedef struct {
 
     z_stream            stream;
 
+    ngx_buf_t           *output_buffer;
+    ngx_chain_t         *output_chain;
+
     ngx_http_upload_ctx_t       *upload_ctx;
     ngx_upload_content_filter_t *next_content_filter; 
+    ngx_unzip_decompression_method_t *decompression_method;
 
     unsigned int        discard_data:1;
 } ngx_unzip_ctx_t;
@@ -107,14 +173,51 @@ static ngx_int_t ngx_http_unzip_start_handler(ngx_http_upload_ctx_t *u);
 static void ngx_http_unzip_finish_handler(ngx_http_upload_ctx_t *u);
 static void ngx_http_unzip_abort_handler(ngx_http_upload_ctx_t *u);
 static ngx_int_t ngx_http_unzip_data_handler(ngx_http_upload_ctx_t *u,
-    u_char *buf, size_t len);
+    ngx_chain_t *chain);
 
-static ngx_upload_content_filter_t ngx_unzip_content_filter = {
+static ngx_int_t ngx_http_unzip_retrieve_start(ngx_unzip_ctx_t *ctx);
+static void ngx_http_unzip_retrieve_finish(ngx_unzip_ctx_t *ctx);
+static void ngx_http_unzip_retrieve_abort(ngx_unzip_ctx_t *ctx);
+static ngx_int_t ngx_http_unzip_retrieve_process_chain(ngx_unzip_ctx_t *ctx, ngx_chain_t *chain);
+
+static ngx_int_t ngx_http_unzip_inflate_start(ngx_unzip_ctx_t *ctx);
+static void ngx_http_unzip_inflate_finish(ngx_unzip_ctx_t *ctx);
+static void ngx_http_unzip_inflate_abort(ngx_unzip_ctx_t *ctx);
+static ngx_int_t ngx_http_unzip_inflate_process_chain(ngx_unzip_ctx_t *ctx, ngx_chain_t *chain);
+
+static char *ngx_http_unzip_window(ngx_conf_t *cf, void *post, void *data);
+
+static ngx_int_t
+ngx_http_unzip_set_decompression_method(ngx_unzip_ctx_t *ctx, uint16_t compression_method_number);
+static ngx_int_t ngx_http_unzip_parse_file_name(ngx_unzip_ctx_t *ctx, ngx_str_t *file_name);
+
+static ngx_unzip_decompression_method_t /* {{{ */
+ngx_unzip_decompression_methods[] = {
+
+    { ZIP_METHOD_STORED,
+      ngx_http_unzip_retrieve_start,
+      ngx_http_unzip_retrieve_finish,
+      ngx_http_unzip_retrieve_abort,
+      ngx_http_unzip_retrieve_process_chain },
+
+    { ZIP_METHOD_DEFLATED,
+      ngx_http_unzip_inflate_start,
+      ngx_http_unzip_inflate_finish,
+      ngx_http_unzip_inflate_abort,
+      ngx_http_unzip_inflate_process_chain },
+
+    ngx_unzip_decompression_method_null
+} /* }}} */;
+
+static ngx_upload_content_filter_t /* {{{ */
+ngx_http_unzip_content_filter = {
     ngx_http_unzip_start_handler,
     ngx_http_unzip_finish_handler,
     ngx_http_unzip_abort_handler,
     ngx_http_unzip_data_handler
-};
+} /* }}} */;
+
+static ngx_conf_post_handler_pt  ngx_http_unzip_window_p = ngx_http_unzip_window;
 
 static ngx_command_t  ngx_http_unzip_filter_commands[] = { /* {{{ */
 
@@ -129,13 +232,34 @@ static ngx_command_t  ngx_http_unzip_filter_commands[] = { /* {{{ */
       NULL },
 
     /*
-     * Specifies size and numbers of buffers to use for decompressing
+     * Specifies size and number of buffers to use for decompressing
      */
     { ngx_string("unzip_buffers"),
       NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
       ngx_conf_set_bufs_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_unzip_conf_t, bufs),
+      NULL },
+
+    { ngx_string("unzip_window"),
+      NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_size_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_unzip_conf_t, wbits),
+      &ngx_http_unzip_window_p },
+
+    { ngx_string("unzip_set_form_field"),
+      NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
+      ngx_conf_set_size_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_unzip_conf_t, wbits),
+      NULL },
+
+    { ngx_string("unzip_aggregate_form_field"),
+      NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
+      ngx_conf_set_size_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_unzip_conf_t, wbits),
       NULL },
 
       ngx_null_command
@@ -170,8 +294,6 @@ ngx_module_t  ngx_http_unzip_filter_module = { /* {{{ */
     NGX_MODULE_V1_PADDING
 }; /* }}} */
 
-u_char unzip_buffer[4096];
-
 static char * /* {{{ ngx_http_unzip_command */
 ngx_http_unzip_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
@@ -180,34 +302,401 @@ ngx_http_unzip_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     ngx_str_t                   *value;
 
-    unsigned int                on = 0;
-
     ulcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_upload_module);
 
     value = cf->args->elts;
 
-    if(ngx_strcmp(value[1].data, "on") == 0) {
-        on = 1;
-        uzcf->recursive = 0;
-    }
-
-    if(ngx_strcmp(value[1].data, "recursive") == 0) {
-        on = 1;
-        uzcf->recursive = 1;
-    }
-
-    if(on) {
-        if(ngx_http_upload_add_filter(ulcf, &ngx_unzip_content_filter, cf->pool) != NGX_OK) {
-            return NGX_CONF_ERROR;
+    if(cf->args->nelts > 1) {
+        if(ngx_strcmp(value[1].data, "recursive") == 0) {
+            uzcf->recursive = 1;
         }
+    }
+
+    if(ngx_http_upload_add_filter(ulcf, &ngx_http_unzip_content_filter, cf->pool) != NGX_OK) {
+        return NGX_CONF_ERROR;
     }
 
     return NGX_CONF_OK;
 } /* }}} */
 
-static ngx_int_t
-ngx_unzip_decompress_start(ngx_unzip_ctx_t *ctx) {
+static ngx_int_t /* {{{ ngx_http_unzip_process_chain */
+ngx_http_unzip_process_chain(ngx_unzip_ctx_t *ctx, ngx_chain_t *chain) {
+    ngx_int_t result;
+    ngx_buf_t *buf;
+
+    while(chain != NULL && !chain->buf->last_in_chain) {
+        buf = chain->buf;
+
+        for(buf = chain->buf ; buf->pos != buf->last ; buf->pos++) {
+            switch(ctx->state) {
+                case unzip_state_signature: /* {{{ */
+                    if(ctx->current_field_pos == 0) {
+                        ctx->current_field_len = SIGNATURE_LEN;
+                        ctx->current_field_ptr = ctx->current_field = ctx->accumulator;
+                    }
+
+                    *ctx->current_field_ptr++ = *buf->pos;
+                    ctx->current_field_pos++;
+                    
+                    if(ctx->current_field_pos == ctx->current_field_len) {
+                        ctx->current_field_pos = 0;
+
+                        switch(EXTRACT_LONG(ctx->current_field)) {
+                            case LOCAL_DATA_HEADER_SIGNATURE:
+                                ctx->state = unzip_state_local_data_header;
+                                break;
+                            case ARCHIVE_EXTRA_DATA_SIGNATURE:
+                                ctx->state = unzip_state_local_data_header;
+                                break;
+                            case CENTRAL_FILE_HEADER_SIGNATURE:
+                                ctx->state = unzip_state_file_header;
+                                break;
+                            case DIGITAL_SIGNATURE_HEADER_SIGNATURE:
+                                ctx->state = unzip_state_digital_sig_header;
+                                break;
+                            default:
+                                return NGX_UNZIP_MALFORMED;
+                        }
+                    }
+                    break; /* }}} */
+                case unzip_state_local_data_header: /* {{{ */
+                    if(ctx->current_field_pos == 0) {
+                        ctx->current_field_len = LOCAL_DATA_HEADER_LEN - SIGNATURE_LEN;
+                        ctx->current_field_ptr = ctx->current_field = ctx->accumulator;
+
+                        ctx->discard_data = 0;
+                    }
+
+                    *ctx->current_field_ptr++ = *buf->pos;
+                    ctx->current_field_pos++;
+
+                    if(ctx->current_field_pos == ctx->current_field_len) {
+                        ctx->current_field_pos = 0;
+
+                        ctx->version_needed = EXTRACT_SHORT(ctx->current_field);
+                        ctx->flags = EXTRACT_SHORT(ctx->current_field + 2);
+                        ctx->compression_method_number = EXTRACT_SHORT(ctx->current_field + 4);
+                        ctx->last_mod_time = EXTRACT_SHORT(ctx->current_field + 6);
+                        ctx->last_mod_date = EXTRACT_SHORT(ctx->current_field + 8);
+                        ctx->crc32 = EXTRACT_LONG(ctx->current_field + 10);
+                        ctx->compressed_size = EXTRACT_LONG(ctx->current_field + 14);
+                        ctx->uncompressed_size = EXTRACT_LONG(ctx->current_field + 18);
+
+                        ctx->file_name_len = EXTRACT_SHORT(ctx->current_field + 22);
+                        ctx->extra_field_len = EXTRACT_SHORT(ctx->current_field + 24);
+
+                        if(ngx_http_unzip_set_decompression_method(ctx,
+                            ctx->compression_method_number) != NGX_OK) 
+                        {
+                            return NGX_UNZIP_MALFORMED;
+                        } 
+
+                        if(ctx->version_needed > ZIP_VERSION)
+                        {
+                            return NGX_UNZIP_MALFORMED;
+                        }
+
+                        if(ctx->file_name_len > 0)
+                            ctx->state = unzip_state_file_name;
+                        else if(ctx->extra_field_len > 0)
+                            ctx->state = unzip_state_extra_field;
+                        else if(ctx->compressed_size > 0)
+                            ctx->state = unzip_state_file_data;
+                        else if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
+                            ctx->state = unzip_state_data_descriptor;
+                        else
+                            ctx->state = unzip_state_signature;
+                    }
+                    break; /* }}} */
+                case unzip_state_file_name: /* {{{ */
+                    if(ctx->current_field_pos == 0) {
+                        ctx->file_name.len = ctx->file_name_len;
+
+                        ctx->file_name.data = ngx_palloc(ctx->pool, ctx->file_name_len + 1);
+
+                        if(ctx->file_name.data == NULL) {
+                            return NGX_UPLOAD_NOMEM;
+                        }
+
+                        ctx->current_field_len = ctx->file_name_len;
+                        ctx->current_field_ptr = ctx->current_field = ctx->file_name.data;
+                    }
+
+                    *ctx->current_field_ptr++ = *buf->pos;
+                    ctx->current_field_pos++;
+                    
+                    if(ctx->current_field_pos == ctx->current_field_len) {
+                        ctx->current_field_pos = 0;
+
+                        *ctx->current_field_ptr = '\0';
+
+                        if(ngx_http_unzip_parse_file_name(ctx, &ctx->file_name) != NGX_OK) {
+                            return NGX_UNZIP_MALFORMED;
+                        }
+
+                        if(ctx->extra_field_len > 0)
+                            ctx->state = unzip_state_extra_field;
+                        else if(ctx->compressed_size > 0)
+                            ctx->state = unzip_state_file_data;
+                        else if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
+                            ctx->state = unzip_state_data_descriptor;
+                        else
+                            ctx->state = unzip_state_signature;
+                    }
+                    break; /* }}} */
+                case unzip_state_extra_field:
+                    if(ctx->current_field_pos == 0) {
+                        ctx->current_field_len = ctx->extra_field_len;
+                    }
+
+                    ctx->current_field_pos++;
+                    
+                    if(ctx->current_field_pos == ctx->current_field_len) {
+                        ctx->current_field_pos = 0;
+
+                        if(ctx->compressed_size > 0)
+                            ctx->state = unzip_state_file_data;
+                        else if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
+                            ctx->state = unzip_state_data_descriptor;
+                        else
+                            ctx->state = unzip_state_signature;
+                    }
+                    break;
+                case unzip_state_file_data:
+                    if(ctx->current_field_pos == 0) {
+                        ctx->current_field_len = ctx->compressed_size;
+
+                        if(ctx->decompression_method->start(ctx) != NGX_OK) {
+                            ctx->discard_data = 1;
+                        }
+                    }
+        
+                    if(!ctx->discard_data) {
+                        result = ctx->decompression_method->process_chain(ctx, chain);
+
+                        buf->pos--;
+
+                        if(result == NGX_AGAIN) {
+                            return NGX_AGAIN;
+                        }
+
+                        if(result != NGX_OK) {
+                            ctx->discard_data = 1;
+
+                            ctx->decompression_method->abort(ctx);
+
+                            ctx->current_field_pos++;
+                        }
+                    }else
+                        ctx->current_field_pos++;
+                    
+                    if(ctx->current_field_pos >= ctx->current_field_len) {
+                        if(!ctx->discard_data)
+                            ctx->decompression_method->finish(ctx);
+
+                        ctx->current_field_pos = 0;
+
+                        if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
+                            ctx->state = unzip_state_data_descriptor;
+                        else
+                            ctx->state = unzip_state_signature;
+                    }
+                    break;
+                case unzip_state_data_descriptor:
+                    if(ctx->current_field_pos == 0) {
+                        ctx->current_field_len = DATA_DESCRIPTOR_LEN;
+                        ctx->current_field_ptr = ctx->current_field = ctx->accumulator;
+                    }
+
+                    *ctx->current_field_ptr++ = *buf->pos;
+                    ctx->current_field_pos++;
+                    
+                    if(ctx->current_field_pos == ctx->current_field_len) {
+                        ctx->current_field_pos = 0;
+                        ctx->state = unzip_state_signature;
+                    }
+                    break;
+                case unzip_state_decryption_header:
+                    break;
+                case unzip_state_extra_data_record:
+                    break;
+                case unzip_state_file_header:
+                    if(ctx->current_field_pos == 0) {
+                        ctx->current_field_len = FILE_HEADER_LEN - SIGNATURE_LEN;
+                        ctx->current_field_ptr = ctx->current_field = ctx->accumulator;
+                    }
+
+                    *ctx->current_field_ptr++ = *buf->pos;
+                    ctx->current_field_pos++;
+                    
+                    if(ctx->current_field_pos == ctx->current_field_len) {
+                        ctx->current_field_pos = 0;
+                        ctx->state = unzip_state_signature;
+                    }
+                    break;
+                case unzip_state_digital_sig_header:
+                    break;
+                case unzip_state_central_directory_end:
+                    if(ctx->current_field_pos == 0) {
+                        ctx->current_field_len = END_OF_CENTRAL_DIR_LEN - SIGNATURE_LEN;
+                        ctx->current_field_ptr = ctx->current_field = ctx->accumulator;
+                    }
+
+                    *ctx->current_field_ptr++ = *buf->pos;
+                    ctx->current_field_pos++;
+                    
+                    if(ctx->current_field_pos == ctx->current_field_len) {
+                        ctx->current_field_pos = 0;
+                        ctx->state = unzip_state_signature;
+                    }
+                    break;
+                case unzip_state_finish:
+                    break;
+            }
+        }
+
+        chain = chain->next;
+    }
+
+    return NGX_OK;
+} /* }}} */
+
+static ngx_int_t /* {{{ ngx_http_unzip_start_handler */
+ngx_http_unzip_start_handler(ngx_http_upload_ctx_t *u) {
+    ngx_unzip_conf_t           *uzcf;
+    ngx_unzip_ctx_t            *ctx, *parent;
+
+    uzcf = ngx_http_get_module_loc_conf(u->request, ngx_http_unzip_filter_module);
+
+    ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
+
+    parent = ctx;
+
+    ctx = ngx_pcalloc(u->request->pool, sizeof(ngx_unzip_ctx_t));
+    if (ctx == NULL) {
+        return NGX_UPLOAD_NOMEM;
+    }
+
+    ctx->parent = parent;
+
+    ngx_http_set_ctx(u->request, ctx, ngx_http_unzip_filter_module);
+
+    ctx->state = unzip_state_signature;
+    ctx->upload_ctx = u;
+    ctx->next_content_filter = ngx_upload_get_next_content_filter(u);
+
+    ctx->pool = u->request->pool; 
+    ctx->log = u->log; 
+
+    return NGX_OK;
+} /* }}} */
+
+static void /* {{{ ngx_http_unzip_finish_handler */
+ngx_http_unzip_finish_handler(ngx_http_upload_ctx_t *u) {
+    ngx_unzip_ctx_t            *ctx;
+
+    ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
+
+    if (ctx->state == unzip_state_file_data) {
+        if(!ctx->discard_data)
+            ctx->decompression_method->abort(ctx);
+    }
+
+    ngx_http_set_ctx(u->request, ctx->parent, ngx_http_unzip_filter_module);
+} /* }}} */
+
+static void /* {{{ ngx_http_unzip_abort_handler */
+ngx_http_unzip_abort_handler(ngx_http_upload_ctx_t *u) {
+    ngx_unzip_ctx_t            *ctx;
+
+    ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
+
+    if (ctx->state == unzip_state_file_data) {
+        if(!ctx->discard_data)
+            ctx->decompression_method->abort(ctx);
+    }
+
+    ngx_http_set_ctx(u->request, ctx->parent, ngx_http_unzip_filter_module);
+} /* }}} */
+
+static ngx_int_t /* {{{ ngx_http_unzip_data_handler */
+ngx_http_unzip_data_handler(ngx_http_upload_ctx_t *u, ngx_chain_t *chain) {
+    ngx_unzip_ctx_t            *ctx;
+
+    ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
+
+    return ngx_http_unzip_process_chain(ctx, chain);
+} /* }}} */
+
+static void * /* {{{ ngx_http_unzip_create_loc_conf */
+ngx_http_unzip_create_loc_conf(ngx_conf_t *cf)
+{
+    ngx_unzip_conf_t  *conf;
+
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_unzip_conf_t));
+    if (conf == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    conf->wbits = 15;
+    conf->bufs.num = 4;
+    conf->bufs.size = ngx_pagesize;
+
+    /*
+     * conf->bufs
+     * zeroed by ngx_pcalloc
+     */
+
+    return conf;
+} /* }}} */
+
+static char * /* {{{ ngx_http_unzip_window */
+ngx_http_unzip_window(ngx_conf_t *cf, void *post, void *data)
+{
+    int *np = data;
+
+    int  wbits, wsize;
+
+    wbits = 15;
+
+    for (wsize = 32 * 1024; wsize > 256; wsize >>= 1) {
+
+        if (wsize == *np) {
+            *np = wbits;
+
+            return NGX_CONF_OK;
+        }
+
+        wbits--;
+    }
+
+    return "must be 512, 1k, 2k, 4k, 8k, 16k, or 32k";
+} /* }}} */
+
+static ngx_int_t /* {{{ ngx_http_unzip_set_decompression_method */
+ngx_http_unzip_set_decompression_method(ngx_unzip_ctx_t *ctx, uint16_t compression_method)
+{
+    ngx_unzip_decompression_method_t *m = ngx_unzip_decompression_methods; 
+
+    while(m->method != 0xffff) {
+        if(m->method== compression_method) {
+            ctx->decompression_method = m;
+            return NGX_OK;
+        }
+
+        m++;
+    }
+
+    ngx_log_error(NGX_LOG_ALERT, ctx->log, 0,
+          "unknown compression method: %u", compression_method);
+
+    return NGX_ERROR;
+} /* }}} */
+
+static ngx_int_t /* {{{ ngx_http_unzip_inflate_start */
+ngx_http_unzip_inflate_start(ngx_unzip_ctx_t *ctx) {
     ngx_int_t rc;
+    ngx_unzip_conf_t           *uzcf;
 
     ctx->stream.zalloc = Z_NULL;
     ctx->stream.zfree = Z_NULL;
@@ -215,7 +704,28 @@ ngx_unzip_decompress_start(ngx_unzip_ctx_t *ctx) {
     ctx->stream.avail_in = 0;
     ctx->stream.next_in = Z_NULL;
 
-    rc = inflateInit2(&ctx->stream, -15);
+    uzcf = ngx_http_get_module_loc_conf(ctx->upload_ctx->request, ngx_http_unzip_filter_module); 
+
+    if(ctx->output_buffer == NULL) {
+        ctx->output_buffer = ngx_create_temp_buf(ctx->pool, uzcf->bufs.size);
+
+        if (ctx->output_buffer == NULL) {
+            return NGX_ERROR;
+        }
+    }
+
+    if(ctx->output_chain == NULL) {
+        ctx->output_chain = ngx_alloc_chain_link(ctx->pool);
+
+        if (ctx->output_chain == NULL) {
+            return NGX_ERROR;
+        }
+
+        ctx->output_chain->buf = ctx->output_buffer;
+        ctx->output_chain->next = NULL;
+    }
+
+    rc = inflateInit2(&ctx->stream, -uzcf->wbits);
 
     if (rc != Z_OK) {
         ngx_log_error(NGX_LOG_ALERT, ctx->log, 0,
@@ -224,13 +734,7 @@ ngx_unzip_decompress_start(ngx_unzip_ctx_t *ctx) {
     }
 
     ngx_log_error(NGX_LOG_INFO, ctx->log, 0,
-          "started unzipping file \"%V\"", &ctx->file_name);
-
-    rc = ngx_upload_set_file_name(ctx->upload_ctx, &ctx->file_name);
-
-    if(rc != NGX_OK) {
-        goto cleanup;
-    }
+          "started inflating file \"%V\"", &ctx->file_name);
 
     if(ctx->next_content_filter->start) {
         rc = ctx->next_content_filter->start(ctx->upload_ctx);
@@ -246,349 +750,168 @@ ngx_unzip_decompress_start(ngx_unzip_ctx_t *ctx) {
 cleanup:
     inflateEnd(&ctx->stream);    
     return rc;
-}
+} /* }}} */
 
-static void
-ngx_unzip_decompress_finish(ngx_unzip_ctx_t *ctx) {
+static void /* {{{ ngx_http_unzip_inflate_finish */
+ngx_http_unzip_inflate_finish(ngx_unzip_ctx_t *ctx) {
     if(ctx->next_content_filter->finish)
         ctx->next_content_filter->finish(ctx->upload_ctx);
 
     inflateEnd(&ctx->stream);
 
     ngx_log_error(NGX_LOG_INFO, ctx->log, 0,
-          "finished unzipping file \"%V\"", &ctx->file_name);
-}
+          "finished inflating file \"%V\"", &ctx->file_name);
+} /* }}} */
 
-static void
-ngx_unzip_decompress_abort(ngx_unzip_ctx_t *ctx) {
+static void /* {{{ ngx_http_unzip_inflate_abort */
+ngx_http_unzip_inflate_abort(ngx_unzip_ctx_t *ctx) {
     if(ctx->next_content_filter->abort)
         ctx->next_content_filter->abort(ctx->upload_ctx);
 
     inflateEnd(&ctx->stream);
 
     ngx_log_error(NGX_LOG_INFO, ctx->log, 0,
-          "aborted unzipping file \"%V\"", &ctx->file_name);
-}
+          "aborted inflating file \"%V\"", &ctx->file_name);
+} /* }}} */
 
-static ngx_int_t
-ngx_unzip_decompress_data(ngx_unzip_ctx_t *ctx, u_char *start, u_char *end) {
+static ngx_int_t /* {{{ ngx_http_unzip_inflate_process_chain */
+ngx_http_unzip_inflate_process_chain(ngx_unzip_ctx_t *ctx, ngx_chain_t *chain) {
     int rc;
-    size_t remaining = end - start;
+    size_t remaining;
 
-    if(ctx->current_field_len - ctx->current_field_pos > remaining)
-        ctx->stream.avail_in = remaining;
-    else
-        ctx->stream.avail_in = ctx->current_field_len - ctx->current_field_pos;
+    while(chain != NULL && !chain->buf->last_in_chain) {
+        remaining = chain->buf->last - chain->buf->pos;
 
-    ctx->stream.next_in = start;
+        if(ctx->current_field_len - ctx->current_field_pos > remaining)
+            ctx->stream.avail_in = remaining;
+        else
+            ctx->stream.avail_in = ctx->current_field_len - ctx->current_field_pos;
 
-    do{
-        ctx->stream.avail_out = sizeof(unzip_buffer);
-        ctx->stream.next_out = unzip_buffer;
+        ctx->stream.next_in = chain->buf->pos;
 
-        rc = inflate(&ctx->stream, Z_NO_FLUSH);
+        do{
+            ctx->stream.avail_out = ctx->output_buffer->end - ctx->output_buffer->start;
+            ctx->stream.next_out = ctx->output_buffer->pos = ctx->output_buffer->start;
 
-        if(rc == Z_OK || rc == Z_STREAM_END) {
-            if(ctx->next_content_filter->process_buf)
-                ctx->next_content_filter->process_buf(ctx->upload_ctx, 
-                    unzip_buffer, sizeof(unzip_buffer) - ctx->stream.avail_out);
-        }
+            rc = inflate(&ctx->stream, Z_NO_FLUSH);
+
+            if(rc == Z_OK || rc == Z_STREAM_END) {
+                ctx->output_buffer->last = ctx->stream.next_out;
+
+                if(ctx->next_content_filter->process_chain)
+                    ctx->next_content_filter->process_chain(ctx->upload_ctx, 
+                        ctx->output_chain);
+            }
+
+            if(rc == Z_STREAM_END) {
+                break;
+            }
+
+            if (rc != Z_OK) {
+                ngx_log_error(NGX_LOG_ALERT, ctx->log, 0,
+                      "inflate() failed: %d", rc);
+                return NGX_ERROR;
+            }
+        }while(ctx->stream.avail_out == 0 && rc == Z_OK);
+
+        ctx->current_field_pos += (ctx->stream.next_in - chain->buf->pos);
+
+        chain->buf->pos = ctx->stream.next_in;
 
         if(rc == Z_STREAM_END) {
-            return ctx->stream.next_in - start;
+            break;
         }
 
-        if (rc != Z_OK) {
-            ngx_log_error(NGX_LOG_ALERT, ctx->log, 0,
-                  "inflate() failed: %d", rc);
-            return NGX_ERROR;
-        }
-    }while(ctx->stream.avail_out == 0);
+        chain = chain->next;
+    }
 
-    return ctx->stream.next_in - start;
-}
+    if(ctx->current_field_len - ctx->current_field_pos == 0)
+        return NGX_OK;
+    else
+        return NGX_AGAIN;
+} /* }}} */
 
-static ngx_int_t
-unzip_process_buf(ngx_unzip_ctx_t *ctx, u_char *start, u_char *end) {
-    ngx_int_t result;
+static ngx_int_t /* {{{ ngx_http_unzip_retrieve_start */
+ngx_http_unzip_retrieve_start(ngx_unzip_ctx_t *ctx) {
+    ngx_int_t rc;
+
+    rc = ngx_upload_set_file_name(ctx->upload_ctx, &ctx->file_name);
+
+    if(rc != NGX_OK)
+        return rc;
+
+    ngx_log_error(NGX_LOG_INFO, ctx->log, 0,
+          "started retrieving file \"%V\"", &ctx->file_name);
+
+    if(ctx->next_content_filter->start)
+        return ctx->next_content_filter->start(ctx->upload_ctx);
+    else
+        return NGX_OK;
+} /* }}} */
+
+static void /* {{{ ngx_http_unzip_retrieve_finish */
+ngx_http_unzip_retrieve_finish(ngx_unzip_ctx_t *ctx) {
+    if(ctx->next_content_filter->finish)
+        ctx->next_content_filter->finish(ctx->upload_ctx);
+
+    ngx_log_error(NGX_LOG_INFO, ctx->log, 0,
+          "finished retrieving file \"%V\"", &ctx->file_name);
+} /* }}} */
+
+static void /* {{{ ngx_http_unzip_retrieve_abort */
+ngx_http_unzip_retrieve_abort(ngx_unzip_ctx_t *ctx) {
+    if(ctx->next_content_filter->abort)
+        ctx->next_content_filter->abort(ctx->upload_ctx);
+
+    ngx_log_error(NGX_LOG_INFO, ctx->log, 0,
+          "aborted retrieving file \"%V\"", &ctx->file_name);
+} /* }}} */
+
+static ngx_int_t /* {{{ ngx_http_unzip_retrieve_process_chain */
+ngx_http_unzip_retrieve_process_chain(ngx_unzip_ctx_t *ctx, ngx_chain_t *chain) {
+    ngx_chain_t *cl;
+
+    if(ctx->next_content_filter->process_chain) {
+        for(cl = chain; cl; cl = cl->next)
+            ctx->current_field_pos += (cl->buf->pos - cl->buf->last);
+
+        return ctx->next_content_filter->process_chain(ctx->upload_ctx, chain); 
+    }else
+        return NGX_OK;
+} /* }}} */
+
+static ngx_int_t /* {{{ ngx_http_unzip_parse_file_name */
+ngx_http_unzip_parse_file_name(ngx_unzip_ctx_t *ctx, ngx_str_t *file_name) {
     u_char *p;
+    ngx_int_t rc;
 
-    for(p = start ; p != end ; p++) {
-        switch(ctx->state) {
-            case unzip_state_signature:
-                if(ctx->current_field_pos == 0) {
-                    ctx->current_field_len = SIGNATURE_LEN;
-                    ctx->current_field_ptr = ctx->current_field = ctx->buffer;
-                }
+    ngx_str_t archive_path = { file_name->len, file_name->data };
+    ngx_str_t element_name = { file_name->len, file_name->data };
 
-                *ctx->current_field_ptr++ = *p;
-                ctx->current_field_pos++;
-                
-                if(ctx->current_field_pos == ctx->current_field_len) {
-                    ctx->current_field_pos = 0;
+    for(p = file_name->data + file_name->len - 1; p >= file_name->data ; p--, archive_path.len--) {
+        if(*p == '/') {
+            element_name.data = p + 1;
+            element_name.len = file_name->len - (p - file_name->data) - 1;
 
-                    switch(EXTRACT_LONG(ctx->current_field)) {
-                        case LOCAL_DATA_HEADER_SIGNATURE:
-                            ctx->state = unzip_state_local_data_header;
-                            break;
-                        case ARCHIVE_EXTRA_DATA_SIGNATURE:
-                            ctx->state = unzip_state_local_data_header;
-                            break;
-                        case CENTRAL_FILE_HEADER_SIGNATURE:
-                            ctx->state = unzip_state_file_header;
-                            break;
-                        default:
-                            return NGX_UNZIP_MALFORMED;
-                    }
-                }
-                break;
-            case unzip_state_local_data_header:
-                if(ctx->current_field_pos == 0) {
-                    ctx->current_field_len = LOCAL_DATA_HEADER_LEN - SIGNATURE_LEN;
-                    ctx->current_field_ptr = ctx->current_field = ctx->buffer;
-
-                    ctx->discard_data = 0;
-                }
-
-                *ctx->current_field_ptr++ = *p;
-                ctx->current_field_pos++;
-
-                if(ctx->current_field_pos == ctx->current_field_len) {
-                    ctx->current_field_pos = 0;
-
-                    ctx->version_needed = EXTRACT_SHORT(ctx->current_field);
-                    ctx->flags = EXTRACT_SHORT(ctx->current_field + 2);
-                    ctx->compression_method = EXTRACT_SHORT(ctx->current_field + 4);
-                    ctx->last_mod_time = EXTRACT_SHORT(ctx->current_field + 6);
-                    ctx->last_mod_date = EXTRACT_SHORT(ctx->current_field + 8);
-                    ctx->crc32 = EXTRACT_LONG(ctx->current_field + 10);
-                    ctx->compressed_size = EXTRACT_LONG(ctx->current_field + 14);
-                    ctx->uncompressed_size = EXTRACT_LONG(ctx->current_field + 18);
-
-                    ctx->file_name_len = EXTRACT_SHORT(ctx->current_field + 22);
-                    ctx->extra_field_len = EXTRACT_SHORT(ctx->current_field + 24);
-
-                    if(ctx->compression_method != ZIP_METHOD_STORED &&
-                        ctx->compression_method != ZIP_METHOD_DEFLATED)
-                    {
-                        return NGX_UNZIP_MALFORMED;
-                    }
-
-                    if(ctx->version_needed > ZIP_VERSION)
-                    {
-                        return NGX_UNZIP_MALFORMED;
-                    }
-
-                    if(ctx->file_name_len > 0)
-                        ctx->state = unzip_state_file_name;
-                    else if(ctx->extra_field_len > 0)
-                        ctx->state = unzip_state_extra_field;
-                    else if(ctx->compressed_size > 0)
-                        ctx->state = unzip_state_file_data;
-                    else if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
-                        ctx->state = unzip_state_data_descriptor;
-                    else
-                        ctx->state = unzip_state_signature;
-                }
-                break;
-            case unzip_state_file_name:
-                if(ctx->current_field_pos == 0) {
-                    ctx->file_name.len = ctx->file_name_len;
-
-                    ctx->file_name.data = ngx_palloc(ctx->pool, ctx->file_name_len + 1);
-
-                    if(ctx->file_name.data == NULL) {
-                        return NGX_UPLOAD_NOMEM;
-                    }
-
-                    ctx->current_field_len = ctx->file_name_len;
-                    ctx->current_field_ptr = ctx->current_field = ctx->file_name.data;
-                }
-
-                *ctx->current_field_ptr++ = *p;
-                ctx->current_field_pos++;
-                
-                if(ctx->current_field_pos == ctx->current_field_len) {
-                    ctx->current_field_pos = 0;
-
-                    *ctx->current_field_ptr = '\0';
-
-                    if(ctx->extra_field_len > 0)
-                        ctx->state = unzip_state_extra_field;
-                    else if(ctx->compressed_size > 0)
-                        ctx->state = unzip_state_file_data;
-                    else if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
-                        ctx->state = unzip_state_data_descriptor;
-                    else
-                        ctx->state = unzip_state_signature;
-                }
-                break;
-            case unzip_state_extra_field:
-                if(ctx->current_field_pos == 0) {
-                    ctx->current_field_len = ctx->extra_field_len;
-                }
-
-                ctx->current_field_pos++;
-                
-                if(ctx->current_field_pos == ctx->current_field_len) {
-                    ctx->current_field_pos = 0;
-
-                    if(ctx->compressed_size > 0)
-                        ctx->state = unzip_state_file_data;
-                    else if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
-                        ctx->state = unzip_state_data_descriptor;
-                    else
-                        ctx->state = unzip_state_signature;
-                }
-                break;
-            case unzip_state_file_data:
-                if(ctx->current_field_pos == 0) {
-                    ctx->current_field_len = ctx->compressed_size;
-
-                    if(ngx_unzip_decompress_start(ctx) != NGX_OK) {
-                        ctx->discard_data = 1;
-                    }
-                }
-    
-                if(!ctx->discard_data) {
-                    result = ngx_unzip_decompress_data(ctx, p, end);
-
-                    if(result < 0) {
-                        ctx->discard_data = 1;
-
-                        ngx_unzip_decompress_abort(ctx);
-
-                        ctx->current_field_pos++;
-                    }else{
-                        ctx->current_field_pos += result;
-                        p += (result - 1);
-                    }
-                }else
-                    ctx->current_field_pos++;
-                
-                if(ctx->current_field_pos == ctx->current_field_len) {
-                    if(!ctx->discard_data)
-                        ngx_unzip_decompress_finish(ctx);
-
-                    ctx->current_field_pos = 0;
-
-                    if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
-                        ctx->state = unzip_state_data_descriptor;
-                    else
-                        ctx->state = unzip_state_signature;
-                }
-                break;
-            case unzip_state_data_descriptor:
-                if(ctx->current_field_pos == 0) {
-                    ctx->current_field_len = DATA_DESCRIPTOR_LEN;
-                    ctx->current_field_ptr = ctx->current_field = ctx->buffer;
-                }
-
-                *ctx->current_field_ptr++ = *p;
-                ctx->current_field_pos++;
-                
-                if(ctx->current_field_pos == ctx->current_field_len) {
-                    ctx->current_field_pos = 0;
-                    ctx->state = unzip_state_signature;
-                }
-                break;
-            case unzip_state_decryption_header:
-                break;
-            case unzip_state_extra_data_record:
-                break;
-            case unzip_state_file_header:
-                if(ctx->current_field_pos == 0) {
-                    ctx->current_field_len = FILE_HEADER_LEN - SIGNATURE_LEN;
-                    ctx->current_field_ptr = ctx->current_field = ctx->buffer;
-                }
-
-                *ctx->current_field_ptr++ = *p;
-                ctx->current_field_pos++;
-                
-                if(ctx->current_field_pos == ctx->current_field_len) {
-                    ctx->current_field_pos = 0;
-                    ctx->state = unzip_state_signature;
-                }
-                break;
-                break;
-            case unzip_state_central_directory_end:
-                break;
-            case unzip_state_finish:
-                break;
+            goto set;
         }
     }
 
-    return NGX_OK;
-}
+    archive_path.len = 0;
 
-static ngx_int_t
-ngx_http_unzip_start_handler(ngx_http_upload_ctx_t *u) {
-    ngx_unzip_conf_t           *uzcf;
-    ngx_unzip_ctx_t            *ctx;
+set:
+    rc = ngx_upload_set_file_name(ctx->upload_ctx, &element_name);
 
-    uzcf = ngx_http_get_module_loc_conf(u->request, ngx_http_unzip_filter_module);
-
-    ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
-
-    if (ctx == NULL) {
-        ctx = ngx_pcalloc(u->request->pool, sizeof(ngx_unzip_ctx_t));
-        if (ctx == NULL) {
-            return NGX_UPLOAD_NOMEM;
-        }
-
-        ngx_http_set_ctx(u->request, ctx, ngx_http_unzip_filter_module);
+    if(rc != NGX_OK) {
+        return rc;
     }
 
-    ctx->state = unzip_state_signature;
-    ctx->upload_ctx = u;
-    ctx->next_content_filter = ngx_upload_get_next_content_filter(u);
+    rc = ngx_upload_set_archive_path(ctx->upload_ctx, &archive_path);
 
-    ctx->pool = u->request->pool; 
-    ctx->log = u->log; 
+    if(rc != NGX_OK) {
+        return rc;
+    }
 
     return NGX_OK;
-}
-
-static void
-ngx_http_unzip_finish_handler(ngx_http_upload_ctx_t *u) {
-}
-
-static void
-ngx_http_unzip_abort_handler(ngx_http_upload_ctx_t *u) {
-    ngx_unzip_ctx_t            *ctx;
-
-    ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
-
-    if (ctx->state == unzip_state_file_data) {
-        if(!ctx->discard_data)
-            ngx_unzip_decompress_abort(ctx);
-    }
-}
-
-static ngx_int_t
-ngx_http_unzip_data_handler(ngx_http_upload_ctx_t *u, u_char *buf, size_t len) {
-    ngx_unzip_ctx_t            *ctx;
-
-    ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
-
-    return unzip_process_buf(ctx, buf, buf + len);
-}
-
-static void *
-ngx_http_unzip_create_loc_conf(ngx_conf_t *cf)
-{
-    ngx_unzip_conf_t  *conf;
-
-    conf = ngx_pcalloc(cf->pool, sizeof(ngx_unzip_conf_t));
-    if (conf == NULL) {
-        return NGX_CONF_ERROR;
-    }
-
-    /*
-     * conf->bufs,
-     * zeroed by ngx_pcalloc
-     */
-
-    return conf;
-}
+} /* }}} */
 

--- a/ngx_http_unzip_filter_module.c
+++ b/ngx_http_unzip_filter_module.c
@@ -1,0 +1,594 @@
+/*
+ * Copyright (C) 2006, 2008 Valery Kholodkov
+ */
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+#include <zlib.h>
+
+#include <ngx_http_upload.h>
+
+#define NGX_UNZIP_MALFORMED NGX_UPLOAD_MALFORMED
+
+#define LOCAL_DATA_HEADER_SIGNATURE         0x04034b50
+#define ARCHIVE_EXTRA_DATA_SIGNATURE        0x08064b50
+#define CENTRAL_FILE_HEADER_SIGNATURE       0x02014b50
+#define SIGNATURE_LEN                       4 
+#define LOCAL_DATA_HEADER_LEN               30
+#define FILE_HEADER_LEN                     46
+#define DATA_DESCRIPTOR_LEN                 12
+
+#define ZIP_METHOD_STORED                   0
+#define ZIP_METHOD_DEFLATED                 8
+
+#define ZIP_FLAG_HAVE_DATA_DESC             0x0008
+
+#define ZIP_VERSION                         20
+
+#if (NGX_HAVE_LITTLE_ENDIAN && NGX_HAVE_NONALIGNED)
+#define EXTRACT_SHORT(x) (uint16_t)(*(x) | *((x)+1) << 8)
+#define EXTRACT_LONG(x) (uint32_t)(*(x) | *((x)+1) << 8 | *((x)+2) << 16 | *((x)+3) << 24)
+#else
+#define EXTRACT_SHORT(x) (uint16_t)(*(x) << 8 | *((x)+1))
+#define EXTRACT_LONG(x) (uint32_t)(*(x) << 24 | *((x)+1) << 16 | *((x)+2) << 8 | *((x)+3))
+#endif
+
+typedef struct {
+    ngx_bufs_t           bufs;
+    unsigned int         recursive:1;
+} ngx_unzip_conf_t;
+
+typedef enum {
+    unzip_state_signature,
+    unzip_state_local_data_header,
+    unzip_state_file_name,
+    unzip_state_extra_field,
+    unzip_state_file_data,
+    unzip_state_data_descriptor,
+    unzip_state_decryption_header,
+    unzip_state_extra_data_record,
+    unzip_state_file_header,
+    unzip_state_central_directory_end,
+    unzip_state_finish
+} ngx_unzip_state_e;
+
+typedef struct {
+    uint16_t            version_needed;
+    uint16_t            flags;
+    uint16_t            compression_method;
+    uint16_t            last_mod_time;
+    uint16_t            last_mod_date;
+    uint32_t            crc32;
+    size_t              compressed_size;
+    size_t              uncompressed_size;
+    size_t              file_name_len;
+    size_t              extra_field_len;
+} ngx_unzip_local_data_header_t;
+
+typedef struct {
+    ngx_unzip_state_e   state;
+    size_t              current_field_len;
+    size_t              current_field_pos;
+
+    ngx_pool_t          *pool;
+    ngx_log_t           *log;
+
+    u_char              buffer[512];
+
+    u_char              *current_field;
+    u_char              *current_field_ptr;
+
+    uint16_t            version_needed;
+    uint16_t            flags;
+    uint16_t            compression_method;
+    uint16_t            last_mod_time;
+    uint16_t            last_mod_date;
+    uint32_t            crc32;
+    size_t              compressed_size;
+    size_t              uncompressed_size;
+    size_t              file_name_len;
+    size_t              extra_field_len;
+
+    ngx_str_t           file_name;
+
+    z_stream            stream;
+
+    ngx_http_upload_ctx_t       *upload_ctx;
+    ngx_upload_content_filter_t *next_content_filter; 
+
+    unsigned int        discard_data:1;
+} ngx_unzip_ctx_t;
+
+static char * ngx_http_unzip_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static void *ngx_http_unzip_create_loc_conf(ngx_conf_t *cf);
+
+static ngx_int_t ngx_http_unzip_start_handler(ngx_http_upload_ctx_t *u);
+static void ngx_http_unzip_finish_handler(ngx_http_upload_ctx_t *u);
+static void ngx_http_unzip_abort_handler(ngx_http_upload_ctx_t *u);
+static ngx_int_t ngx_http_unzip_data_handler(ngx_http_upload_ctx_t *u,
+    u_char *buf, size_t len);
+
+static ngx_upload_content_filter_t ngx_unzip_content_filter = {
+    ngx_http_unzip_start_handler,
+    ngx_http_unzip_finish_handler,
+    ngx_http_unzip_abort_handler,
+    ngx_http_unzip_data_handler
+};
+
+static ngx_command_t  ngx_http_unzip_filter_commands[] = { /* {{{ */
+
+    /*
+     * Enables unzipping of uploaded file
+     */
+    { ngx_string("unzip"),
+      NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_http_unzip_command,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+
+    /*
+     * Specifies size and numbers of buffers to use for decompressing
+     */
+    { ngx_string("unzip_buffers"),
+      NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
+      ngx_conf_set_bufs_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_unzip_conf_t, bufs),
+      NULL },
+
+      ngx_null_command
+}; /* }}} */
+
+ngx_http_module_t  ngx_http_unzip_filter_module_ctx = { /* {{{ */
+    NULL,                                  /* preconfiguration */
+    NULL,                                  /* postconfiguration */
+
+    NULL,                                  /* create main configuration */
+    NULL,                                  /* init main configuration */
+
+    NULL,                                  /* create server configuration */
+    NULL,                                  /* merge server configuration */
+
+    ngx_http_unzip_create_loc_conf,        /* create location configuration */
+    NULL                                   /* merge location configuration */
+}; /* }}} */
+
+ngx_module_t  ngx_http_unzip_filter_module = { /* {{{ */
+    NGX_MODULE_V1,
+    &ngx_http_unzip_filter_module_ctx,     /* module context */
+    ngx_http_unzip_filter_commands,        /* module directives */
+    NGX_HTTP_MODULE,                       /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+}; /* }}} */
+
+u_char unzip_buffer[4096];
+
+static char * /* {{{ ngx_http_unzip_command */
+ngx_http_unzip_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_unzip_conf_t           *uzcf = conf;
+    ngx_http_upload_loc_conf_t *ulcf;
+
+    ngx_str_t                   *value;
+
+    unsigned int                on = 0;
+
+    ulcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_upload_module);
+
+    value = cf->args->elts;
+
+    if(ngx_strcmp(value[1].data, "on") == 0) {
+        on = 1;
+        uzcf->recursive = 0;
+    }
+
+    if(ngx_strcmp(value[1].data, "recursive") == 0) {
+        on = 1;
+        uzcf->recursive = 1;
+    }
+
+    if(on) {
+        if(ngx_http_upload_add_filter(ulcf, &ngx_unzip_content_filter, cf->pool) != NGX_OK) {
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    return NGX_CONF_OK;
+} /* }}} */
+
+static ngx_int_t
+ngx_unzip_decompress_start(ngx_unzip_ctx_t *ctx) {
+    ngx_int_t rc;
+
+    ctx->stream.zalloc = Z_NULL;
+    ctx->stream.zfree = Z_NULL;
+    ctx->stream.opaque = Z_NULL;
+    ctx->stream.avail_in = 0;
+    ctx->stream.next_in = Z_NULL;
+
+    rc = inflateInit2(&ctx->stream, -15);
+
+    if (rc != Z_OK) {
+        ngx_log_error(NGX_LOG_ALERT, ctx->log, 0,
+              "inflateInit() failed: %d", rc);
+        return NGX_ERROR;
+    }
+
+    ngx_log_error(NGX_LOG_INFO, ctx->log, 0,
+          "started unzipping file \"%V\"", &ctx->file_name);
+
+    rc = ngx_upload_set_file_name(ctx->upload_ctx, &ctx->file_name);
+
+    if(rc != NGX_OK) {
+        goto cleanup;
+    }
+
+    if(ctx->next_content_filter->start) {
+        rc = ctx->next_content_filter->start(ctx->upload_ctx);
+
+        if(rc != NGX_OK) {
+            goto cleanup;
+        }
+
+        return rc;
+    }
+
+    return NGX_OK;
+cleanup:
+    inflateEnd(&ctx->stream);    
+    return rc;
+}
+
+static void
+ngx_unzip_decompress_finish(ngx_unzip_ctx_t *ctx) {
+    if(ctx->next_content_filter->finish)
+        ctx->next_content_filter->finish(ctx->upload_ctx);
+
+    inflateEnd(&ctx->stream);
+
+    ngx_log_error(NGX_LOG_INFO, ctx->log, 0,
+          "finished unzipping file \"%V\"", &ctx->file_name);
+}
+
+static void
+ngx_unzip_decompress_abort(ngx_unzip_ctx_t *ctx) {
+    if(ctx->next_content_filter->abort)
+        ctx->next_content_filter->abort(ctx->upload_ctx);
+
+    inflateEnd(&ctx->stream);
+
+    ngx_log_error(NGX_LOG_INFO, ctx->log, 0,
+          "aborted unzipping file \"%V\"", &ctx->file_name);
+}
+
+static ngx_int_t
+ngx_unzip_decompress_data(ngx_unzip_ctx_t *ctx, u_char *start, u_char *end) {
+    int rc;
+    size_t remaining = end - start;
+
+    if(ctx->current_field_len - ctx->current_field_pos > remaining)
+        ctx->stream.avail_in = remaining;
+    else
+        ctx->stream.avail_in = ctx->current_field_len - ctx->current_field_pos;
+
+    ctx->stream.next_in = start;
+
+    do{
+        ctx->stream.avail_out = sizeof(unzip_buffer);
+        ctx->stream.next_out = unzip_buffer;
+
+        rc = inflate(&ctx->stream, Z_NO_FLUSH);
+
+        if(rc == Z_OK || rc == Z_STREAM_END) {
+            if(ctx->next_content_filter->process_buf)
+                ctx->next_content_filter->process_buf(ctx->upload_ctx, 
+                    unzip_buffer, sizeof(unzip_buffer) - ctx->stream.avail_out);
+        }
+
+        if(rc == Z_STREAM_END) {
+            return ctx->stream.next_in - start;
+        }
+
+        if (rc != Z_OK) {
+            ngx_log_error(NGX_LOG_ALERT, ctx->log, 0,
+                  "inflate() failed: %d", rc);
+            return NGX_ERROR;
+        }
+    }while(ctx->stream.avail_out == 0);
+
+    return ctx->stream.next_in - start;
+}
+
+static ngx_int_t
+unzip_process_buf(ngx_unzip_ctx_t *ctx, u_char *start, u_char *end) {
+    ngx_int_t result;
+    u_char *p;
+
+    for(p = start ; p != end ; p++) {
+        switch(ctx->state) {
+            case unzip_state_signature:
+                if(ctx->current_field_pos == 0) {
+                    ctx->current_field_len = SIGNATURE_LEN;
+                    ctx->current_field_ptr = ctx->current_field = ctx->buffer;
+                }
+
+                *ctx->current_field_ptr++ = *p;
+                ctx->current_field_pos++;
+                
+                if(ctx->current_field_pos == ctx->current_field_len) {
+                    ctx->current_field_pos = 0;
+
+                    switch(EXTRACT_LONG(ctx->current_field)) {
+                        case LOCAL_DATA_HEADER_SIGNATURE:
+                            ctx->state = unzip_state_local_data_header;
+                            break;
+                        case ARCHIVE_EXTRA_DATA_SIGNATURE:
+                            ctx->state = unzip_state_local_data_header;
+                            break;
+                        case CENTRAL_FILE_HEADER_SIGNATURE:
+                            ctx->state = unzip_state_file_header;
+                            break;
+                        default:
+                            return NGX_UNZIP_MALFORMED;
+                    }
+                }
+                break;
+            case unzip_state_local_data_header:
+                if(ctx->current_field_pos == 0) {
+                    ctx->current_field_len = LOCAL_DATA_HEADER_LEN - SIGNATURE_LEN;
+                    ctx->current_field_ptr = ctx->current_field = ctx->buffer;
+
+                    ctx->discard_data = 0;
+                }
+
+                *ctx->current_field_ptr++ = *p;
+                ctx->current_field_pos++;
+
+                if(ctx->current_field_pos == ctx->current_field_len) {
+                    ctx->current_field_pos = 0;
+
+                    ctx->version_needed = EXTRACT_SHORT(ctx->current_field);
+                    ctx->flags = EXTRACT_SHORT(ctx->current_field + 2);
+                    ctx->compression_method = EXTRACT_SHORT(ctx->current_field + 4);
+                    ctx->last_mod_time = EXTRACT_SHORT(ctx->current_field + 6);
+                    ctx->last_mod_date = EXTRACT_SHORT(ctx->current_field + 8);
+                    ctx->crc32 = EXTRACT_LONG(ctx->current_field + 10);
+                    ctx->compressed_size = EXTRACT_LONG(ctx->current_field + 14);
+                    ctx->uncompressed_size = EXTRACT_LONG(ctx->current_field + 18);
+
+                    ctx->file_name_len = EXTRACT_SHORT(ctx->current_field + 22);
+                    ctx->extra_field_len = EXTRACT_SHORT(ctx->current_field + 24);
+
+                    if(ctx->compression_method != ZIP_METHOD_STORED &&
+                        ctx->compression_method != ZIP_METHOD_DEFLATED)
+                    {
+                        return NGX_UNZIP_MALFORMED;
+                    }
+
+                    if(ctx->version_needed > ZIP_VERSION)
+                    {
+                        return NGX_UNZIP_MALFORMED;
+                    }
+
+                    if(ctx->file_name_len > 0)
+                        ctx->state = unzip_state_file_name;
+                    else if(ctx->extra_field_len > 0)
+                        ctx->state = unzip_state_extra_field;
+                    else if(ctx->compressed_size > 0)
+                        ctx->state = unzip_state_file_data;
+                    else if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
+                        ctx->state = unzip_state_data_descriptor;
+                    else
+                        ctx->state = unzip_state_signature;
+                }
+                break;
+            case unzip_state_file_name:
+                if(ctx->current_field_pos == 0) {
+                    ctx->file_name.len = ctx->file_name_len;
+
+                    ctx->file_name.data = ngx_palloc(ctx->pool, ctx->file_name_len + 1);
+
+                    if(ctx->file_name.data == NULL) {
+                        return NGX_UPLOAD_NOMEM;
+                    }
+
+                    ctx->current_field_len = ctx->file_name_len;
+                    ctx->current_field_ptr = ctx->current_field = ctx->file_name.data;
+                }
+
+                *ctx->current_field_ptr++ = *p;
+                ctx->current_field_pos++;
+                
+                if(ctx->current_field_pos == ctx->current_field_len) {
+                    ctx->current_field_pos = 0;
+
+                    *ctx->current_field_ptr = '\0';
+
+                    if(ctx->extra_field_len > 0)
+                        ctx->state = unzip_state_extra_field;
+                    else if(ctx->compressed_size > 0)
+                        ctx->state = unzip_state_file_data;
+                    else if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
+                        ctx->state = unzip_state_data_descriptor;
+                    else
+                        ctx->state = unzip_state_signature;
+                }
+                break;
+            case unzip_state_extra_field:
+                if(ctx->current_field_pos == 0) {
+                    ctx->current_field_len = ctx->extra_field_len;
+                }
+
+                ctx->current_field_pos++;
+                
+                if(ctx->current_field_pos == ctx->current_field_len) {
+                    ctx->current_field_pos = 0;
+
+                    if(ctx->compressed_size > 0)
+                        ctx->state = unzip_state_file_data;
+                    else if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
+                        ctx->state = unzip_state_data_descriptor;
+                    else
+                        ctx->state = unzip_state_signature;
+                }
+                break;
+            case unzip_state_file_data:
+                if(ctx->current_field_pos == 0) {
+                    ctx->current_field_len = ctx->compressed_size;
+
+                    if(ngx_unzip_decompress_start(ctx) != NGX_OK) {
+                        ctx->discard_data = 1;
+                    }
+                }
+    
+                if(!ctx->discard_data) {
+                    result = ngx_unzip_decompress_data(ctx, p, end);
+
+                    if(result < 0) {
+                        ctx->discard_data = 1;
+
+                        ngx_unzip_decompress_abort(ctx);
+
+                        ctx->current_field_pos++;
+                    }else{
+                        ctx->current_field_pos += result;
+                        p += (result - 1);
+                    }
+                }else
+                    ctx->current_field_pos++;
+                
+                if(ctx->current_field_pos == ctx->current_field_len) {
+                    if(!ctx->discard_data)
+                        ngx_unzip_decompress_finish(ctx);
+
+                    ctx->current_field_pos = 0;
+
+                    if(ctx->flags & ZIP_FLAG_HAVE_DATA_DESC)
+                        ctx->state = unzip_state_data_descriptor;
+                    else
+                        ctx->state = unzip_state_signature;
+                }
+                break;
+            case unzip_state_data_descriptor:
+                if(ctx->current_field_pos == 0) {
+                    ctx->current_field_len = DATA_DESCRIPTOR_LEN;
+                    ctx->current_field_ptr = ctx->current_field = ctx->buffer;
+                }
+
+                *ctx->current_field_ptr++ = *p;
+                ctx->current_field_pos++;
+                
+                if(ctx->current_field_pos == ctx->current_field_len) {
+                    ctx->current_field_pos = 0;
+                    ctx->state = unzip_state_signature;
+                }
+                break;
+            case unzip_state_decryption_header:
+                break;
+            case unzip_state_extra_data_record:
+                break;
+            case unzip_state_file_header:
+                if(ctx->current_field_pos == 0) {
+                    ctx->current_field_len = FILE_HEADER_LEN - SIGNATURE_LEN;
+                    ctx->current_field_ptr = ctx->current_field = ctx->buffer;
+                }
+
+                *ctx->current_field_ptr++ = *p;
+                ctx->current_field_pos++;
+                
+                if(ctx->current_field_pos == ctx->current_field_len) {
+                    ctx->current_field_pos = 0;
+                    ctx->state = unzip_state_signature;
+                }
+                break;
+                break;
+            case unzip_state_central_directory_end:
+                break;
+            case unzip_state_finish:
+                break;
+        }
+    }
+
+    return NGX_OK;
+}
+
+static ngx_int_t
+ngx_http_unzip_start_handler(ngx_http_upload_ctx_t *u) {
+    ngx_unzip_conf_t           *uzcf;
+    ngx_unzip_ctx_t            *ctx;
+
+    uzcf = ngx_http_get_module_loc_conf(u->request, ngx_http_unzip_filter_module);
+
+    ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
+
+    if (ctx == NULL) {
+        ctx = ngx_pcalloc(u->request->pool, sizeof(ngx_unzip_ctx_t));
+        if (ctx == NULL) {
+            return NGX_UPLOAD_NOMEM;
+        }
+
+        ngx_http_set_ctx(u->request, ctx, ngx_http_unzip_filter_module);
+    }
+
+    ctx->state = unzip_state_signature;
+    ctx->upload_ctx = u;
+    ctx->next_content_filter = ngx_upload_get_next_content_filter(u);
+
+    ctx->pool = u->request->pool; 
+    ctx->log = u->log; 
+
+    return NGX_OK;
+}
+
+static void
+ngx_http_unzip_finish_handler(ngx_http_upload_ctx_t *u) {
+}
+
+static void
+ngx_http_unzip_abort_handler(ngx_http_upload_ctx_t *u) {
+    ngx_unzip_ctx_t            *ctx;
+
+    ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
+
+    if (ctx->state == unzip_state_file_data) {
+        if(!ctx->discard_data)
+            ngx_unzip_decompress_abort(ctx);
+    }
+}
+
+static ngx_int_t
+ngx_http_unzip_data_handler(ngx_http_upload_ctx_t *u, u_char *buf, size_t len) {
+    ngx_unzip_ctx_t            *ctx;
+
+    ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
+
+    return unzip_process_buf(ctx, buf, buf + len);
+}
+
+static void *
+ngx_http_unzip_create_loc_conf(ngx_conf_t *cf)
+{
+    ngx_unzip_conf_t  *conf;
+
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_unzip_conf_t));
+    if (conf == NULL) {
+        return NGX_CONF_ERROR;
+    }
+
+    /*
+     * conf->bufs,
+     * zeroed by ngx_pcalloc
+     */
+
+    return conf;
+}
+

--- a/ngx_http_unzip_filter_module.c
+++ b/ngx_http_unzip_filter_module.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2008 Valery Kholodkov
+ * Copyright (C) 2008 Valery Kholodkov
  */
 #include <ngx_config.h>
 #include <ngx_core.h>
@@ -169,7 +169,12 @@ typedef struct ngx_unzip_ctx_s {
         ngx_unzip_extra_data_record_t   extra_data_record;
     };
 
+    ngx_str_t           archive_name;
     ngx_str_t           file_name;
+
+    ngx_str_t           prev_elm, current_elm;
+    ngx_str_t           prev_archive_path, current_archive_path;
+    ngx_int_t           entry_no;
 
     void                *preallocated;
     char                *free_mem;
@@ -260,7 +265,7 @@ static ngx_command_t  ngx_http_unzip_filter_commands[] = { /* {{{ */
     /*
      * Enables unzipping of uploaded file
      */
-    { ngx_string("unzip"),
+    { ngx_string("upload_unzip"),
       NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_http_unzip_command,
       NGX_HTTP_LOC_CONF_OFFSET,
@@ -270,7 +275,7 @@ static ngx_command_t  ngx_http_unzip_filter_commands[] = { /* {{{ */
     /*
      * Specifies size and number of buffers to use for decompressing
      */
-    { ngx_string("unzip_buffers"),
+    { ngx_string("upload_unzip_buffers"),
       NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
       ngx_conf_set_bufs_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
@@ -280,7 +285,7 @@ static ngx_command_t  ngx_http_unzip_filter_commands[] = { /* {{{ */
     /*
      * Specifies size window to use for decompressing
      */
-    { ngx_string("unzip_window"),
+    { ngx_string("upload_unzip_window"),
       NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_size_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
@@ -291,7 +296,7 @@ static ngx_command_t  ngx_http_unzip_filter_commands[] = { /* {{{ */
      * Specifies a form field with a special content to generate
      * in output form
      */
-    { ngx_string("unzip_set_form_field"),
+    { ngx_string("upload_unzip_set_form_field"),
       NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
       ngx_conf_set_size_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
@@ -302,7 +307,7 @@ static ngx_command_t  ngx_http_unzip_filter_commands[] = { /* {{{ */
      * Specifies a form field with a special aggregate content to generate
      * in output form
      */
-    { ngx_string("unzip_aggregate_form_field"),
+    { ngx_string("upload_unzip_aggregate_form_field"),
       NGX_HTTP_LOC_CONF|NGX_CONF_TAKE2,
       ngx_conf_set_size_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
@@ -312,7 +317,7 @@ static ngx_command_t  ngx_http_unzip_filter_commands[] = { /* {{{ */
     /*
      * Specifies the maximal length of a file name in archive
      */
-    { ngx_string("unzip_max_file_name_len"),
+    { ngx_string("upload_unzip_max_file_name_len"),
       NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_size_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
@@ -852,8 +857,10 @@ static ngx_int_t /* {{{ ngx_http_unzip_start_handler */
 ngx_http_unzip_start_handler(ngx_http_upload_ctx_t *u) {
     ngx_unzip_conf_t           *uzcf;
     ngx_unzip_ctx_t            *ctx, *parent;
+    ngx_http_upload_loc_conf_t *ulcf;
 
     uzcf = ngx_http_get_module_loc_conf(u->request, ngx_http_unzip_filter_module);
+    ulcf = ngx_http_get_module_loc_conf(u->request, ngx_http_upload_module);
 
     ctx = ngx_http_get_module_ctx(u->request, ngx_http_unzip_filter_module);
 
@@ -875,11 +882,26 @@ ngx_http_unzip_start_handler(ngx_http_upload_ctx_t *u) {
 
     ctx->state = unzip_state_signature;
     ctx->upload_ctx = u;
-    ctx->next_field_filter = ngx_upload_get_next_field_filter(u);
-    ctx->next_content_filter = ngx_upload_get_next_content_filter(u);
 
     ctx->pool = u->request->pool; 
     ctx->log = u->log; 
+
+    ctx->next_field_filter = ngx_upload_get_next_field_filter(u);
+    ctx->next_content_filter = ngx_upload_get_next_content_filter(u);
+
+    ngx_upload_get_archive_elm(u, &ctx->prev_elm);
+
+    ngx_upload_get_archive_path(u, &ctx->prev_archive_path);
+
+    ngx_upload_get_file_name(u, &ctx->archive_name);
+
+    ctx->entry_no = 0;
+
+    ctx->current_elm.len = ctx->prev_elm.len + ulcf->archive_elm_separator.len + NGX_OFF_T_LEN;
+    ctx->current_elm.data = ngx_palloc(ctx->pool, ctx->current_elm.len);
+
+    if(ctx->current_elm.data == NULL)
+        return NGX_UPLOAD_NOMEM;
 
     return NGX_OK;
 } /* }}} */
@@ -895,6 +917,10 @@ ngx_http_unzip_finish_handler(ngx_http_upload_ctx_t *u) {
             ctx->decompression_method->abort(ctx);
     }
 
+    ngx_upload_set_archive_elm(u, &ctx->prev_elm);
+
+    ngx_upload_set_archive_path(u, &ctx->prev_archive_path);
+
     ngx_http_set_ctx(u->request, ctx->parent, ngx_http_unzip_filter_module);
 } /* }}} */
 
@@ -908,6 +934,10 @@ ngx_http_unzip_abort_handler(ngx_http_upload_ctx_t *u) {
         if(!ctx->discard_data)
             ctx->decompression_method->abort(ctx);
     }
+
+    ngx_upload_set_archive_elm(u, &ctx->prev_elm);
+
+    ngx_upload_set_archive_path(u, &ctx->prev_archive_path);
 
     ngx_http_set_ctx(u->request, ctx->parent, ngx_http_unzip_filter_module);
 } /* }}} */
@@ -1118,14 +1148,18 @@ static ngx_int_t /* {{{ ngx_http_unzip_inflate_process_chain */
 ngx_http_unzip_inflate_process_chain(ngx_unzip_ctx_t *ctx, ngx_chain_t *chain) {
     int rc;
     size_t remaining;
+    int flush;
 
     while(chain != NULL && !chain->buf->last_in_chain) {
         remaining = chain->buf->last - chain->buf->pos;
 
-        if(ctx->current_field_len - ctx->current_field_pos > remaining)
+        if(ctx->current_field_len - ctx->current_field_pos > remaining) {
             ctx->stream.avail_in = remaining;
-        else
+            flush = Z_NO_FLUSH;
+        }else{
             ctx->stream.avail_in = ctx->current_field_len - ctx->current_field_pos;
+            flush = Z_SYNC_FLUSH;
+        }
 
         ctx->stream.next_in = chain->buf->pos;
 
@@ -1133,7 +1167,21 @@ ngx_http_unzip_inflate_process_chain(ngx_unzip_ctx_t *ctx, ngx_chain_t *chain) {
             ctx->stream.avail_out = ctx->output_buffer->end - ctx->output_buffer->start;
             ctx->stream.next_out = ctx->output_buffer->pos = ctx->output_buffer->start;
 
-            rc = inflate(&ctx->stream, Z_NO_FLUSH);
+            ngx_log_debug5(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+                           "inflate in: ai:%ud ni:%p ao:%ud no:%p fl:%d",
+                           ctx->stream.avail_in, ctx->stream.next_in,
+                           ctx->stream.avail_out, ctx->stream.next_out,
+                           flush
+                          );
+
+            rc = inflate(&ctx->stream, flush);
+
+            ngx_log_debug5(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+                           "inflate out: ai:%ud ni:%p ao:%ud no:%p rc:%d",
+                           ctx->stream.avail_in, ctx->stream.next_in,
+                           ctx->stream.avail_out, ctx->stream.next_out,
+                           rc
+                          );
 
             if(rc == Z_OK || rc == Z_STREAM_END) {
                 ctx->output_buffer->last = ctx->stream.next_out;
@@ -1155,7 +1203,7 @@ ngx_http_unzip_inflate_process_chain(ngx_unzip_ctx_t *ctx, ngx_chain_t *chain) {
                       "inflate() failed: %d", rc);
                 return NGX_ERROR;
             }
-        }while(ctx->stream.avail_out == 0 && rc == Z_OK);
+        }while(ctx->stream.avail_out == 0 && ctx->stream.avail_in > 0 && rc == Z_OK);
 
         ctx->current_field_pos += (ctx->stream.next_in - chain->buf->pos);
 
@@ -1229,6 +1277,37 @@ ngx_http_unzip_extract_process_chain(ngx_unzip_ctx_t *ctx, ngx_chain_t *chain) {
         return NGX_OK;
 } /* }}} */
 
+static void /* {{{ ngx_http_unzip_set_archive_elm */
+ngx_http_unzip_set_archive_elm(ngx_unzip_ctx_t *ctx, off_t elm_id) {
+    ngx_http_upload_loc_conf_t *ulcf;
+
+    ulcf = ngx_http_get_module_loc_conf(ctx->upload_ctx->request, ngx_http_upload_module);
+
+    ctx->current_elm.len = ngx_sprintf(ctx->current_elm.data, "%V%V%O", &ctx->prev_elm, &ulcf->archive_elm_separator, elm_id) - ctx->current_elm.data;
+
+    ngx_upload_set_archive_elm(ctx->upload_ctx, &ctx->current_elm);
+} /* }}} */
+
+static ngx_int_t /* {{{ ngx_http_unzip_set_archive_path */
+ngx_http_unzip_set_archive_path(ngx_unzip_ctx_t *ctx, ngx_str_t *file_name, ngx_str_t *path) {
+    ngx_http_upload_loc_conf_t *ulcf;
+
+    ulcf = ngx_http_get_module_loc_conf(ctx->upload_ctx->request, ngx_http_upload_module);
+
+    ctx->current_archive_path.len = ctx->prev_archive_path.len + file_name->len + ulcf->archive_path_separator.len + path->len;
+
+    ctx->current_archive_path.data = ngx_palloc(ctx->pool, ctx->current_archive_path.len);
+
+    if(ctx->current_archive_path.data == NULL)
+        return NGX_UPLOAD_NOMEM;
+
+    ctx->current_archive_path.len = ngx_sprintf(ctx->current_archive_path.data, "%V%V%V%V", &ctx->prev_archive_path, file_name, &ulcf->archive_path_separator, path) - ctx->current_archive_path.data;
+
+    ngx_upload_set_archive_path(ctx->upload_ctx, &ctx->current_archive_path);
+
+    return NGX_OK;
+} /* }}} */
+
 static ngx_int_t /* {{{ ngx_http_unzip_parse_file_name */
 ngx_http_unzip_parse_file_name(ngx_unzip_ctx_t *ctx, ngx_str_t *file_name) {
     u_char *p;
@@ -1251,11 +1330,7 @@ ngx_http_unzip_parse_file_name(ngx_unzip_ctx_t *ctx, ngx_str_t *file_name) {
     archive_path.len = 0;
 
 set:
-    rc = ngx_upload_set_file_name(ctx->upload_ctx, &element_name);
-
-    if(rc != NGX_OK) {
-        return rc;
-    }
+    ngx_upload_set_file_name(ctx->upload_ctx, &element_name);
 
     rc = ngx_upload_set_exten(ctx->upload_ctx, &element_name, &exten);
 
@@ -1269,17 +1344,15 @@ set:
         return rc;
     }
 
-    rc = ngx_upload_set_content_type(ctx->upload_ctx, &content_type);
+    ngx_upload_set_content_type(ctx->upload_ctx, &content_type);
+
+    rc = ngx_http_unzip_set_archive_path(ctx, &ctx->archive_name, &archive_path);
 
     if(rc != NGX_OK) {
         return rc;
     }
 
-    rc = ngx_upload_set_archive_path(ctx->upload_ctx, &archive_path);
-
-    if(rc != NGX_OK) {
-        return rc;
-    }
+    ngx_http_unzip_set_archive_elm(ctx, ctx->entry_no++);
 
     return NGX_OK;
 } /* }}} */

--- a/ngx_http_upload.h
+++ b/ngx_http_upload.h
@@ -95,7 +95,7 @@ struct ngx_http_upload_loc_conf_s;
 
 typedef struct {
     ngx_str_t                           content_type;
-    struct ngx_http_upload_loc_conf_s   *conf;
+    ngx_http_core_loc_conf_t            *conf;
 } ngx_upload_content_type_map_t;
 
 /*
@@ -180,6 +180,7 @@ typedef struct ngx_http_upload_ctx_s {
 
     ngx_http_request_t  *request;
     ngx_log_t           *log;
+    void                **original_loc_conf;
 
     ngx_file_t          output_file;
     ngx_chain_t         *chain;

--- a/ngx_http_upload.h
+++ b/ngx_http_upload.h
@@ -38,6 +38,7 @@
 #define NGX_UPLOAD_NOMEM        -2
 #define NGX_UPLOAD_IOERROR      -3
 #define NGX_UPLOAD_SCRIPTERROR  -4
+#define NGX_UPLOAD_TOOLARGE     -5
 
 /*
  * State of multipart/form-data parser
@@ -120,13 +121,17 @@ typedef struct ngx_http_upload_loc_conf_s {
     ngx_uint_t        store_access;
     size_t            buffer_size;
     size_t            max_header_len;
+    size_t            max_output_body_len;
+    off_t             max_file_size;
     ngx_array_t       *field_templates;
     ngx_array_t       *aggregate_field_templates;
     ngx_array_t       *field_filters;
     ngx_array_t       *cleanup_statuses;
+    ngx_flag_t         forward_args;
 
     ngx_array_t       *content_filters;
     ngx_array_t       *content_type_map;
+    ngx_array_t       *void_content_types;
 
     ngx_str_t         archive_elm_separator;
     ngx_str_t         archive_path_separator;

--- a/ngx_http_upload.h
+++ b/ngx_http_upload.h
@@ -96,6 +96,18 @@ typedef struct {
 } ngx_upload_content_type_map_t;
 
 /*
+ * Upload cleanup record
+ */
+typedef struct ngx_http_upload_cleanup_s {
+    ngx_fd_t                         fd;
+    u_char                           *filename;
+    ngx_http_headers_out_t           *headers_out;
+    ngx_array_t                      *cleanup_statuses;
+    ngx_log_t                        *log;
+    unsigned int                     aborted:1;
+} ngx_upload_cleanup_t;
+
+/*
  * Upload configuration for specific location
  */
 typedef struct ngx_http_upload_loc_conf_s {
@@ -109,12 +121,14 @@ typedef struct ngx_http_upload_loc_conf_s {
     ngx_array_t       *field_templates;
     ngx_array_t       *aggregate_field_templates;
     ngx_array_t       *field_filters;
+    ngx_array_t       *cleanup_statuses;
 
     ngx_array_t       *content_filters;
     ngx_array_t       *content_type_map;
 
     unsigned int      md5:1;
     unsigned int      sha1:1;
+    unsigned int      crc32:1;
 } ngx_http_upload_loc_conf_t;
 
 typedef struct ngx_http_upload_md5_ctx_s {
@@ -166,6 +180,7 @@ typedef struct ngx_http_upload_ctx_s {
 
     ngx_http_upload_md5_ctx_t   *md5_ctx;    
     ngx_http_upload_sha1_ctx_t  *sha1_ctx;    
+    uint32_t                    crc32;    
 
     ngx_array_t         *current_content_filter_chain;    
     ngx_uint_t          current_content_filter_idx;
@@ -173,10 +188,13 @@ typedef struct ngx_http_upload_ctx_s {
     unsigned int        first_part:1;
     unsigned int        discard_data:1;
     unsigned int        is_file:1;
+    unsigned int        calculate_crc32:1;
 } ngx_http_upload_ctx_t;
 
 ngx_module_t  ngx_http_upload_module;
 
+ngx_int_t ngx_upload_set_exten(ngx_http_upload_ctx_t *u, ngx_str_t *file_name, ngx_str_t *exten);
+ngx_int_t ngx_upload_resolve_content_type(ngx_http_upload_ctx_t *u, ngx_str_t *exten, ngx_str_t *content_type);
 ngx_int_t ngx_upload_set_file_name(ngx_http_upload_ctx_t *ctx, ngx_str_t *file_name);
 ngx_int_t ngx_upload_set_content_type(ngx_http_upload_ctx_t *ctx, ngx_str_t *content_type);
 ngx_int_t ngx_upload_set_archive_path(ngx_http_upload_ctx_t *ctx, ngx_str_t *archive_path);

--- a/ngx_http_upload.h
+++ b/ngx_http_upload.h
@@ -82,7 +82,7 @@ typedef struct {
     ngx_int_t (*start)(struct ngx_http_upload_ctx_s *upload_ctx);
     void (*finish)(struct ngx_http_upload_ctx_s *upload_ctx);
     void (*abort)(struct ngx_http_upload_ctx_s *upload_ctx);
-	ngx_int_t (*process_buf)(struct ngx_http_upload_ctx_s *upload_ctx, u_char *buf, size_t len);
+	ngx_int_t (*process_chain)(struct ngx_http_upload_ctx_s *upload_ctx, ngx_chain_t *chain);
 } ngx_upload_content_filter_t;
 
 /*
@@ -144,15 +144,14 @@ typedef struct ngx_http_upload_ctx_s {
     ngx_str_t           field_name;
     ngx_str_t           file_name;
     ngx_str_t           content_type;
+    ngx_str_t           archive_path;
 
-    u_char              *output_buffer;
-    u_char              *output_buffer_end;
-    u_char              *output_buffer_pos;
+    ngx_buf_t           *output_buffer;
 
     ngx_int_t (*start_part_f)(struct ngx_http_upload_ctx_s *upload_ctx);
     void (*finish_part_f)(struct ngx_http_upload_ctx_s *upload_ctx);
     void (*abort_part_f)(struct ngx_http_upload_ctx_s *upload_ctx);
-	ngx_int_t (*flush_output_buffer_f)(struct ngx_http_upload_ctx_s *upload_ctx, u_char *buf, size_t len);
+	ngx_int_t (*process_chain_f)(struct ngx_http_upload_ctx_s *upload_ctx, ngx_chain_t *chain);
 
     ngx_http_request_t  *request;
     ngx_log_t           *log;
@@ -180,6 +179,7 @@ ngx_module_t  ngx_http_upload_module;
 
 ngx_int_t ngx_upload_set_file_name(ngx_http_upload_ctx_t *ctx, ngx_str_t *file_name);
 ngx_int_t ngx_upload_set_content_type(ngx_http_upload_ctx_t *ctx, ngx_str_t *content_type);
+ngx_int_t ngx_upload_set_archive_path(ngx_http_upload_ctx_t *ctx, ngx_str_t *archive_path);
 
 ngx_upload_content_filter_t*
 ngx_upload_get_next_content_filter(ngx_http_upload_ctx_t *ctx);

--- a/ngx_http_upload.h
+++ b/ngx_http_upload.h
@@ -128,6 +128,9 @@ typedef struct ngx_http_upload_loc_conf_s {
     ngx_array_t       *content_filters;
     ngx_array_t       *content_type_map;
 
+    ngx_str_t         archive_elm_separator;
+    ngx_str_t         archive_path_separator;
+
     unsigned int      md5:1;
     unsigned int      sha1:1;
     unsigned int      crc32:1;
@@ -160,6 +163,7 @@ typedef struct ngx_http_upload_ctx_s {
     ngx_str_t           field_name;
     ngx_str_t           file_name;
     ngx_str_t           content_type;
+    ngx_str_t           archive_elm;
     ngx_str_t           archive_path;
 
     ngx_buf_t           *output_buffer;
@@ -197,9 +201,54 @@ ngx_module_t  ngx_http_upload_module;
 
 ngx_int_t ngx_upload_set_exten(ngx_http_upload_ctx_t *u, ngx_str_t *file_name, ngx_str_t *exten);
 ngx_int_t ngx_upload_resolve_content_type(ngx_http_upload_ctx_t *u, ngx_str_t *exten, ngx_str_t *content_type);
-ngx_int_t ngx_upload_set_file_name(ngx_http_upload_ctx_t *ctx, ngx_str_t *file_name);
-ngx_int_t ngx_upload_set_content_type(ngx_http_upload_ctx_t *ctx, ngx_str_t *content_type);
-ngx_int_t ngx_upload_set_archive_path(ngx_http_upload_ctx_t *ctx, ngx_str_t *archive_path);
+
+#define ngx_upload_set_file_name(ctx, fn) \
+    do{ \
+        (ctx)->file_name.data = (fn)->data; \
+        (ctx)->file_name.len = (fn)->len; \
+    }while(0); \
+
+#define ngx_upload_get_file_name(ctx, fn) \
+    do{ \
+        (fn)->data = (ctx)->file_name.data; \
+        (fn)->len = (ctx)->file_name.len; \
+    }while(0); \
+
+#define ngx_upload_set_content_type(ctx, ct) \
+    do{ \
+        (ctx)->content_type.data = (ct)->data; \
+        (ctx)->content_type.len = (ct)->len; \
+    }while(0); \
+
+#define ngx_upload_get_content_type(ctx, ct) \
+    do{ \
+        (ct)->data = (ctx)->content_type.data; \
+        (ct)->len = (ctx)->content_type.len; \
+    }while(0); \
+
+#define ngx_upload_set_archive_elm(ctx, ae) \
+    do{ \
+        (ctx)->archive_elm.data = (ae)->data; \
+        (ctx)->archive_elm.len = (ae)->len; \
+    }while(0); \
+
+#define ngx_upload_get_archive_elm(ctx, ae) \
+    do{ \
+        (ae)->data = (ctx)->archive_elm.data; \
+        (ae)->len = (ctx)->archive_elm.len; \
+    }while(0); \
+
+#define ngx_upload_set_archive_path(ctx, ap) \
+    do{ \
+        (ctx)->archive_path.data = (ap)->data; \
+        (ctx)->archive_path.len = (ap)->len; \
+    }while(0); \
+
+#define ngx_upload_get_archive_path(ctx, ap) \
+    do{ \
+        (ap)->data = (ctx)->archive_path.data; \
+        (ap)->len = (ctx)->archive_path.len; \
+    }while(0); \
 
 ngx_upload_field_filter_t*
 ngx_upload_get_next_field_filter(ngx_http_upload_ctx_t *ctx);

--- a/ngx_http_upload.h
+++ b/ngx_http_upload.h
@@ -85,6 +85,8 @@ typedef struct {
 	ngx_int_t (*process_chain)(struct ngx_http_upload_ctx_s *upload_ctx, ngx_chain_t *chain);
 } ngx_upload_content_filter_t;
 
+typedef ngx_upload_content_filter_t ngx_upload_field_filter_t;
+
 /*
  * Mapping of a content type to slave location config
  */
@@ -198,6 +200,9 @@ ngx_int_t ngx_upload_resolve_content_type(ngx_http_upload_ctx_t *u, ngx_str_t *e
 ngx_int_t ngx_upload_set_file_name(ngx_http_upload_ctx_t *ctx, ngx_str_t *file_name);
 ngx_int_t ngx_upload_set_content_type(ngx_http_upload_ctx_t *ctx, ngx_str_t *content_type);
 ngx_int_t ngx_upload_set_archive_path(ngx_http_upload_ctx_t *ctx, ngx_str_t *archive_path);
+
+ngx_upload_field_filter_t*
+ngx_upload_get_next_field_filter(ngx_http_upload_ctx_t *ctx);
 
 ngx_upload_content_filter_t*
 ngx_upload_get_next_content_filter(ngx_http_upload_ctx_t *ctx);

--- a/ngx_http_upload.h
+++ b/ngx_http_upload.h
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2006, 2008 Valery Kholodkov
+ */
+
+#ifndef _NGX_HTTP_UPLOAD_H_INCLUDED_
+#define _NGX_HTTP_UPLOAD_H_INCLUDED_
+
+#if (NGX_HAVE_OPENSSL_MD5_H)
+#include <openssl/md5.h>
+#else
+#include <md5.h>
+#endif
+
+#if (NGX_OPENSSL_MD5)
+#define  MD5Init    MD5_Init
+#define  MD5Update  MD5_Update
+#define  MD5Final   MD5_Final
+#endif
+
+#if (NGX_HAVE_OPENSSL_SHA1_H)
+#include <openssl/sha.h>
+#else
+#include <sha.h>
+#endif
+
+#define MULTIPART_FORM_DATA_STRING              "multipart/form-data"
+#define BOUNDARY_STRING                         "boundary="
+#define CONTENT_DISPOSITION_STRING              "Content-Disposition:"
+#define CONTENT_TYPE_STRING                     "Content-Type:"
+#define FORM_DATA_STRING                        "form-data"
+#define ATTACHMENT_STRING                       "attachment"
+#define FILENAME_STRING                         "filename=\""
+#define FIELDNAME_STRING                        "name=\""
+
+#define NGX_UPLOAD_SUBMODULE    0x444c5055 // UPLD
+
+#define NGX_UPLOAD_MALFORMED    -1
+#define NGX_UPLOAD_NOMEM        -2
+#define NGX_UPLOAD_IOERROR      -3
+#define NGX_UPLOAD_SCRIPTERROR  -4
+
+/*
+ * State of multipart/form-data parser
+ */
+typedef enum {
+	upload_state_boundary_seek,
+	upload_state_after_boundary,
+	upload_state_headers,
+	upload_state_data,
+	upload_state_finish
+} upload_state_t;
+
+/*
+ * Template for a field to generate in output form
+ */
+typedef struct {
+    ngx_table_elt_t         value;
+    ngx_array_t             *field_lengths;
+    ngx_array_t             *field_values;
+    ngx_array_t             *value_lengths;
+    ngx_array_t             *value_values;
+} ngx_http_upload_field_template_t;
+
+/*
+ * Filter for fields in output form
+ */
+typedef struct {
+#if (NGX_PCRE)
+    ngx_regex_t              *regex;
+    ngx_int_t                ncaptures;
+#else
+    ngx_str_t                text;
+#endif
+} ngx_http_upload_field_filter_t;
+
+struct ngx_http_upload_ctx_s;
+
+/*
+ * Filter for content of certain type
+ */
+typedef struct {
+    ngx_int_t (*start)(struct ngx_http_upload_ctx_s *upload_ctx);
+    void (*finish)(struct ngx_http_upload_ctx_s *upload_ctx);
+    void (*abort)(struct ngx_http_upload_ctx_s *upload_ctx);
+	ngx_int_t (*process_buf)(struct ngx_http_upload_ctx_s *upload_ctx, u_char *buf, size_t len);
+} ngx_upload_content_filter_t;
+
+/*
+ * Mapping of a content type to slave location config
+ */
+struct ngx_http_upload_loc_conf_s;
+
+typedef struct {
+    ngx_str_t                           content_type;
+    struct ngx_http_upload_loc_conf_s   *conf;
+} ngx_upload_content_type_map_t;
+
+/*
+ * Upload configuration for specific location
+ */
+typedef struct ngx_http_upload_loc_conf_s {
+    struct ngx_http_upload_loc_conf_s *parent;
+
+    ngx_str_t         url;
+    ngx_path_t        *store_path;
+    ngx_uint_t        store_access;
+    size_t            buffer_size;
+    size_t            max_header_len;
+    ngx_array_t       *field_templates;
+    ngx_array_t       *aggregate_field_templates;
+    ngx_array_t       *field_filters;
+
+    ngx_array_t       *content_filters;
+    ngx_array_t       *content_type_map;
+
+    unsigned int      md5:1;
+    unsigned int      sha1:1;
+} ngx_http_upload_loc_conf_t;
+
+typedef struct ngx_http_upload_md5_ctx_s {
+    MD5_CTX     md5;
+    u_char      md5_digest[MD5_DIGEST_LENGTH * 2];
+} ngx_http_upload_md5_ctx_t;
+
+typedef struct ngx_http_upload_sha1_ctx_s {
+    SHA_CTX     sha1;
+    u_char      sha1_digest[SHA_DIGEST_LENGTH * 2];
+} ngx_http_upload_sha1_ctx_t;
+
+/*
+ * Upload module context
+ */
+typedef struct ngx_http_upload_ctx_s {
+    ngx_str_t           boundary;
+    u_char              *boundary_start;
+    u_char              *boundary_pos;
+
+    upload_state_t		state;
+
+    u_char              *header_accumulator;
+    u_char              *header_accumulator_end;
+    u_char              *header_accumulator_pos;
+
+    ngx_str_t           field_name;
+    ngx_str_t           file_name;
+    ngx_str_t           content_type;
+
+    u_char              *output_buffer;
+    u_char              *output_buffer_end;
+    u_char              *output_buffer_pos;
+
+    ngx_int_t (*start_part_f)(struct ngx_http_upload_ctx_s *upload_ctx);
+    void (*finish_part_f)(struct ngx_http_upload_ctx_s *upload_ctx);
+    void (*abort_part_f)(struct ngx_http_upload_ctx_s *upload_ctx);
+	ngx_int_t (*flush_output_buffer_f)(struct ngx_http_upload_ctx_s *upload_ctx, u_char *buf, size_t len);
+
+    ngx_http_request_t  *request;
+    ngx_log_t           *log;
+
+    ngx_file_t          output_file;
+    ngx_chain_t         *chain;
+    ngx_chain_t         *last;
+    ngx_chain_t         *checkpoint;
+    size_t              output_body_len;
+
+    ngx_pool_cleanup_t       *cln;
+
+    ngx_http_upload_md5_ctx_t   *md5_ctx;    
+    ngx_http_upload_sha1_ctx_t  *sha1_ctx;    
+
+    ngx_array_t         *current_content_filter_chain;    
+    ngx_uint_t          current_content_filter_idx;
+
+    unsigned int        first_part:1;
+    unsigned int        discard_data:1;
+    unsigned int        is_file:1;
+} ngx_http_upload_ctx_t;
+
+ngx_module_t  ngx_http_upload_module;
+
+ngx_int_t ngx_upload_set_file_name(ngx_http_upload_ctx_t *ctx, ngx_str_t *file_name);
+ngx_int_t ngx_upload_set_content_type(ngx_http_upload_ctx_t *ctx, ngx_str_t *content_type);
+
+ngx_upload_content_filter_t*
+ngx_upload_get_next_content_filter(ngx_http_upload_ctx_t *ctx);
+
+ngx_int_t
+ngx_http_upload_add_filter(ngx_http_upload_loc_conf_t *ulcf,
+    ngx_upload_content_filter_t *cflt, ngx_pool_t *pool);
+
+#endif //_NGX_HTTP_UPLOAD_H_INCLUDED_
+

--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -96,7 +96,7 @@ typedef struct ngx_http_upload_md5_ctx_s {
 } ngx_http_upload_md5_ctx_t;
 
 typedef struct ngx_http_upload_sha1_ctx_s {
-    SHA1_CTX    sha1;
+    SHA_CTX     sha1;
     u_char      sha1_digest[SHA_DIGEST_LENGTH * 2];
 } ngx_http_upload_sha1_ctx_t;
 

--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -1548,7 +1548,7 @@ ngx_http_upload_add_filter(ngx_http_upload_loc_conf_t *ulcf,
 static char * /* {{{ ngx_http_upload_filter_block */
 ngx_http_upload_filter_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-    ngx_http_upload_loc_conf_t *ulcf, *pulcf;
+    ngx_http_upload_loc_conf_t *ulcf, *pulcf = conf;
 
     char                      *rv;
     void                      *mconf;
@@ -1557,9 +1557,7 @@ ngx_http_upload_filter_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_conf_t                 save;
     ngx_http_module_t         *module;
     ngx_http_conf_ctx_t       *ctx, *pctx;
-    ngx_http_core_loc_conf_t  *clcf, *pclcf = conf;
-
-    pulcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_upload_module);
+    ngx_http_core_loc_conf_t  *clcf, *pclcf;
 
     value = cf->args->elts;
 
@@ -1607,9 +1605,16 @@ ngx_http_upload_filter_block(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         }
     }
 
+    pclcf = pctx->loc_conf[ngx_http_core_module.ctx_index];
+
     clcf = ctx->loc_conf[ngx_http_core_module.ctx_index];
     clcf->loc_conf = ctx->loc_conf;
     clcf->name = pclcf->name;
+    clcf->noname = 1;
+
+    if (ngx_http_add_location(cf, &pclcf->locations, clcf) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
 
     save = *cf;
     cf->ctx = ctx;

--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -1003,7 +1003,7 @@ ngx_http_read_upload_client_request_body(ngx_http_request_t *r) {
 
         rb->rest = r->headers_in.content_length_n - preread;
 
-        if (rb->rest <= (size_t) (b->end - b->last)) {
+        if (rb->rest <= (off_t) (b->end - b->last)) {
 
             /* the whole request body may be placed in r->header_in */
 
@@ -1027,7 +1027,7 @@ ngx_http_read_upload_client_request_body(ngx_http_request_t *r) {
     size = clcf->client_body_buffer_size;
     size += size >> 2;
 
-    if (rb->rest < (size_t) size) {
+    if (rb->rest < (ssize_t) size) {
         size = rb->rest;
 
         if (r->request_body_in_single_buf) {
@@ -1135,8 +1135,8 @@ ngx_http_do_read_upload_client_request_body(ngx_http_request_t *r)
 
             size = rb->buf->end - rb->buf->last;
 
-            if (size > rb->rest) {
-                size = rb->rest;
+            if ((off_t)size > rb->rest) {
+                size = (size_t)rb->rest;
             }
 
             n = c->recv(c, rb->buf->last, size);

--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -51,7 +51,7 @@ typedef struct {
     ngx_regex_t              *regex;
     ngx_int_t                ncaptures;
 #else
-    ngx_str_t                name;
+    ngx_str_t                text;
 #endif
 } ngx_http_upload_field_filter_t;
 
@@ -72,23 +72,23 @@ typedef struct {
  * Upload module context
  */
 typedef struct ngx_http_upload_ctx_s {
-	ngx_str_t           boundary;
-	u_char              *boundary_start;
-	u_char              *boundary_pos;
+    ngx_str_t           boundary;
+    u_char              *boundary_start;
+    u_char              *boundary_pos;
 
 	upload_state_t		state;
 
-	u_char              *header_accumulator;
-	u_char              *header_accumulator_end;
-	u_char              *header_accumulator_pos;
+    u_char              *header_accumulator;
+    u_char              *header_accumulator_end;
+    u_char              *header_accumulator_pos;
 
     ngx_str_t           field_name;
     ngx_str_t           file_name;
     ngx_str_t           content_type;
 
-	u_char              *output_buffer;
-	u_char              *output_buffer_end;
-	u_char              *output_buffer_pos;
+    u_char              *output_buffer;
+    u_char              *output_buffer_end;
+    u_char              *output_buffer_pos;
 
     ngx_pool_t          *pool;
 
@@ -588,7 +588,7 @@ static ngx_int_t ngx_http_upload_start_handler(ngx_http_upload_ctx_t *u) { /* {{
                 if(rc == 0)
                     pass_field = 1;
 #else
-                if(ngx_strncmp(f[i].name.data, u->field_name.data, u->field_name.len) == 0)
+                if(ngx_strncmp(f[i].text.data, u->field_name.data, u->field_name.len) == 0)
                     pass_field = 1;
 #endif
             }
@@ -993,8 +993,8 @@ ngx_http_upload_pass_form_field(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     f->ncaptures = n;
 #else
-    f->name.len = value[1].len;
-    f->name.data = value[1].data;
+    f->text.len = value[1].len;
+    f->text.data = value[1].data;
 #endif
 
     return NGX_CONF_OK;

--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -2304,8 +2304,11 @@ ngx_upload_resolve_content_type(ngx_http_upload_ctx_t *u, ngx_str_t *exten, ngx_
         }
     }
 
-    content_type->len = sizeof("application/octet-stream") - 1;
-    content_type->data = (u_char*)"application/octet-stream";
+    /*
+     * Content type defaults to text/plain according to rfc 2388
+     */
+    content_type->len = sizeof("text/plain") - 1;
+    content_type->data = (u_char*)"text/plain";
 
     return NGX_OK;
 } /* }}} */

--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -319,7 +319,7 @@ static ngx_command_t  ngx_http_upload_commands[] = { /* {{{ */
       * Specifies the whether or not to guess content type
       * via file extension for specified content types
       */
-     { ngx_string("upload_void_content_types"),
+     { ngx_string("upload_void_content_type"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
                          |NGX_CONF_1MORE,
        ngx_conf_set_str_array_slot,

--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -438,7 +438,7 @@ ngx_http_upload_handler(ngx_http_request_t *r)
 
     ulcf = ngx_http_get_module_loc_conf(r, ngx_http_upload_module);
 
-    if (!(r->method & NGX_HTTP_POST))
+    if (!(r->method & (NGX_HTTP_POST | NGX_HTTP_PUT)))
         return NGX_DECLINED;
 
     u = ngx_http_get_module_ctx(r, ngx_http_upload_module);

--- a/ngx_upload_discard_filter_module.c
+++ b/ngx_upload_discard_filter_module.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2008 Valery Kholodkov
+ */
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+#include <ngx_http_upload.h>
+
+static ngx_int_t ngx_upload_discard_start_handler(ngx_http_upload_ctx_t *u);
+static void ngx_upload_discard_finish_handler(ngx_http_upload_ctx_t *u);
+static void ngx_upload_discard_abort_handler(ngx_http_upload_ctx_t *u);
+static ngx_int_t ngx_upload_discard_data_handler(ngx_http_upload_ctx_t *u,
+    ngx_chain_t *chain);
+
+static char *ngx_upload_discard_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+
+static ngx_upload_content_filter_t /* {{{ */
+ngx_upload_discard_content_filter = {
+    ngx_upload_discard_start_handler,
+    ngx_upload_discard_finish_handler,
+    ngx_upload_discard_abort_handler,
+    ngx_upload_discard_data_handler
+} /* }}} */;
+
+static ngx_command_t  ngx_upload_discard_filter_commands[] = { /* {{{ */
+
+    /*
+     * Discards uploaded file
+     */
+    { ngx_string("upload_discard"),
+      NGX_HTTP_LOC_CONF|NGX_CONF_NOARGS,
+      ngx_upload_discard_command,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+
+      ngx_null_command
+}; /* }}} */
+
+ngx_http_module_t  ngx_upload_discard_filter_module_ctx = { /* {{{ */
+    NULL,                                  /* preconfiguration */
+    NULL,                                  /* postconfiguration */
+
+    NULL,                                  /* create main configuration */
+    NULL,                                  /* init main configuration */
+
+    NULL,                                  /* create server configuration */
+    NULL,                                  /* merge server configuration */
+
+    NULL,                                  /* create location configuration */
+    NULL                                   /* merge location configuration */
+}; /* }}} */
+
+ngx_module_t  ngx_upload_discard_filter_module = { /* {{{ */
+    NGX_MODULE_V1,
+    &ngx_upload_discard_filter_module_ctx,   /* module context */
+    ngx_upload_discard_filter_commands,      /* module directives */
+    NGX_HTTP_MODULE,                       /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+}; /* }}} */
+
+static char * /* {{{ ngx_upload_discard_command */
+ngx_upload_discard_command(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_upload_loc_conf_t *ulcf;
+
+    ulcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_upload_module);
+
+    if(ngx_http_upload_add_filter(ulcf, &ngx_upload_discard_content_filter, cf->pool) != NGX_OK) {
+        return NGX_CONF_ERROR;
+    }
+
+    return NGX_CONF_OK;
+} /* }}} */
+
+static ngx_int_t /* {{{ ngx_upload_discard_start_handler */
+ngx_upload_discard_start_handler(ngx_http_upload_ctx_t *u) {
+    return NGX_OK;
+} /* }}} */
+
+static void /* {{{ ngx_upload_discard_finish_handler */
+ngx_upload_discard_finish_handler(ngx_http_upload_ctx_t *u) {
+} /* }}} */
+
+static void /* {{{ ngx_upload_discard_abort_handler */
+ngx_upload_discard_abort_handler(ngx_http_upload_ctx_t *u) {
+} /* }}} */
+
+static ngx_int_t /* {{{ ngx_upload_discard_data_handler */
+ngx_upload_discard_data_handler(ngx_http_upload_ctx_t *u, ngx_chain_t *chain) {
+    return NGX_OK;
+} /* }}} */
+

--- a/ngx_upload_unzip_filter_module.c
+++ b/ngx_upload_unzip_filter_module.c
@@ -964,7 +964,7 @@ ngx_upload_unzip_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_size_value(conf->max_file_name_len,
                               prev->max_file_name_len,
-                              (size_t) 256);
+                              (size_t) 512);
 
     return NGX_CONF_OK;
 } /* }}} */

--- a/upload.html
+++ b/upload.html
@@ -3,9 +3,14 @@
 <title>Test upload</title>
 </head>
 <body>
-<h2>Select file to upload</h2>
-<form name="upload" method="POST" enctype="multipart/form-data" action="http://localhost/upload">
+<h2>Select files to upload</h2>
+<form enctype="multipart/form-data" action="http://localhost/upload" method="post">
 <input type="file" name="file1"><br>
+<input type="file" name="file2"><br>
+<input type="file" name="file3"><br>
+<input type="file" name="file4"><br>
+<input type="file" name="file5"><br>
+<input type="file" name="file6"><br>
 <input type="submit" name="submit" value="Upload">
 <input type="hidden" name="test" value="value">
 </form>

--- a/upload.html
+++ b/upload.html
@@ -4,7 +4,7 @@
 </head>
 <body>
 <h2>Select files to upload</h2>
-<form enctype="multipart/form-data" action="http://localhost/upload" method="post">
+<form enctype="multipart/form-data" action="/upload" method="post">
 <input type="file" name="file1"><br>
 <input type="file" name="file2"><br>
 <input type="file" name="file3"><br>


### PR DESCRIPTION
I needed to support upload acceleration for an existing system that used PUT  to send files. weakening the upload method check seemed like the cleanest way to go. notice a few other folks have requested this feature as well.
