### PR TITLE
bug fix: #58 Segfaults after a few nginx reloads

### DIFF
--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -3050,7 +3050,7 @@ ngx_http_upload_merge_path_value(ngx_conf_t *cf, ngx_http_upload_path_t **path, 
         return NGX_CONF_OK;
     }
 
-    *path = ngx_palloc(cf->pool, sizeof(ngx_http_upload_path_t));
+    *path = ngx_pcalloc(cf->pool, sizeof(ngx_http_upload_path_t));
     if(*path == NULL) {
         return NGX_CONF_ERROR;
     }


### PR DESCRIPTION
sometimes when nginx reload conf, the path will be assigned unexpact data if use the alloc function
