### PR TITLE
nginx-upload-module: add openssl lib dependency

### DIFF
--- a/config
+++ b/config
@@ -1,11 +1,10 @@
-USE_MD5=YES
-USE_SHA1=YES
 ngx_addon_name=ngx_http_upload_module
 
 if test -n "$ngx_module_link"; then
     ngx_module_type=HTTP
     ngx_module_name=$ngx_addon_name
     ngx_module_srcs="$ngx_addon_dir/ngx_http_upload_module.c"
+    ngx_module_libs=-lcrypto
 
     . auto/module
 else


### PR DESCRIPTION
When building against 1.11.2+, requires additional
-lcrypto dependency. (Nginx changed crypto approach
and dependencies for openssl are no longer default)

More details found here:
https://github.com/vkholodkov/nginx-upload-module/issues/79

Resolves:
objs/addon/nginx-upload-70bee48f1811eecd255ed094ce9f0fb560c390c3/ngx_http_upload_module.o \
objs/ngx_modules.o \
-ldl -lpthread -lpthread -lpcre -lz -latomic_ops \
-Wl,-E
ngx_http_upload_module.o: In function `ngx_http_upload_flush_output_buffer':
ngx_http_upload_module.c:1625: undefined reference to `MD5_Update'
ngx_http_upload_module.c:1628: undefined reference to `SHA1_Update'
ngx_http_upload_module.c:1631: undefined reference to `SHA256_Update'
ngx_http_upload_module.c:1634: undefined reference to `SHA512_Update'

Signed-off-by: Matthew Weber <matthew.l.weber@gmail.com>