### PR TITLE
Fix for compiling with nginx > 1.11.2

### DIFF
--- a/config
+++ b/config
@@ -1,5 +1,6 @@
 USE_MD5=YES
 USE_SHA1=YES
+USE_OPENSSL=YES
 ngx_addon_name=ngx_http_upload_module
 HTTP_MODULES="$HTTP_MODULES ngx_http_upload_module"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upload_module.c"

--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -8,6 +8,22 @@
 #include <ngx_http.h>
 #include <nginx.h>
 
+#if nginx_version >= 1011002
+
+#include <ngx_md5.h>
+
+typedef ngx_md5_t MD5_CTX;
+
+#define MD5Init ngx_md5_init
+#define MD5Update ngx_md5_update
+#define MD5Final ngx_md5_final
+
+#define MD5_DIGEST_LENGTH 16
+
+#include <openssl/sha.h>
+
+#else
+
 #if (NGX_HAVE_OPENSSL_MD5_H)
 #include <openssl/md5.h>
 #else
@@ -24,6 +40,9 @@
 #include <openssl/sha.h>
 #else
 #include <sha.h>
+#endif
+
+
 #endif
 
 #define MULTIPART_FORM_DATA_STRING              "multipart/form-data"


### PR DESCRIPTION
This patch  fixes compiling nginx-upload-module 2.2 with nginx > 1.11.2.
Checked it on ubuntu 14.04 & 16.04 with nginx versions 1.10.3, 1.12.1, 1.11.3, 1.13.5 and openssl 1.1.0f, 1.02l, 0.9.8zh.

It now requires openssl to build with nginx > 1.11.2.