### PR TITLE
Add HTTP/2 support and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/t/servroot

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+sudo: false
+language: c
+compiler: gcc
+dist: trusty
+
+cache:
+  directories:
+    - perl5
+    - dl
+
+env:
+  global:
+    - TESTNGINX_VER=12152a5
+    - PATH=$TRAVIS_BUILD_DIR/bin:$TRAVIS_BUILD_DIR/nginx/objs:$PATH
+  matrix:
+    - NGINX_VERSION=1.9.15
+    - NGINX_VERSION=1.11.13
+    - NGINX_VERSION=1.12.2
+    - NGINX_VERSION=1.13.8
+
+before_install:
+  - curl --version
+  - mkdir -p {bin,dl}
+  - if [ ! -f dl/nginx-${NGINX_VERSION}.tar.gz ]; then curl -o dl/nginx-${NGINX_VERSION}.tar.gz -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz; fi
+  - if [ ! -f dl/test-nginx-${TESTNGINX_VER}.tar.gz ]; then curl -o dl/test-nginx-${TESTNGINX_VER}.tar.gz -L "https://github.com/openresty/test-nginx/archive/${TESTNGINX_VER}.tar.gz"; fi
+  - if [ ! -f dl/cpanm ]; then curl -o dl/cpanm https://cpanmin.us/; chmod +x dl/cpanm; fi
+  - cp dl/cpanm bin/cpanm
+  - tar -zxvf dl/nginx-${NGINX_VERSION}.tar.gz && mv nginx-${NGINX_VERSION} nginx
+  - cpanm --notest --local-lib=perl5 local::lib && eval $(perl -I perl5/lib/perl5/ -Mlocal::lib)
+  - cpanm --notest dl/test-nginx-${TESTNGINX_VER}.tar.gz
+  - cpanm --notest Test::File
+  - cpanm --notest URI::Query
+  - cd nginx
+  - ./configure --with-http_v2_module --with-http_ssl_module --add-module=..
+  - make
+  - cd ..
+
+script:
+  - prove -r t

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: c
 compiler: gcc
 dist: trusty
@@ -8,10 +8,17 @@ cache:
     - perl5
     - dl
 
+addons:
+  apt:
+    packages:
+      - libssl-dev
+
 env:
   global:
     - TESTNGINX_VER=12152a5
-    - PATH=$TRAVIS_BUILD_DIR/bin:$TRAVIS_BUILD_DIR/nginx/objs:$PATH
+    - PATH=/usr/local/bin:$TRAVIS_BUILD_DIR/nginx/objs:$PATH
+    - CURL=7.58.0
+    - NGHTTP2=1.24.0
   matrix:
     - NGINX_VERSION=1.9.15
     - NGINX_VERSION=1.11.13
@@ -19,17 +26,50 @@ env:
     - NGINX_VERSION=1.13.8
 
 before_install:
-  - curl --version
-  - mkdir -p {bin,dl}
-  - if [ ! -f dl/nginx-${NGINX_VERSION}.tar.gz ]; then curl -o dl/nginx-${NGINX_VERSION}.tar.gz -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz; fi
-  - if [ ! -f dl/test-nginx-${TESTNGINX_VER}.tar.gz ]; then curl -o dl/test-nginx-${TESTNGINX_VER}.tar.gz -L "https://github.com/openresty/test-nginx/archive/${TESTNGINX_VER}.tar.gz"; fi
+  - mkdir -p dl
+  - |
+    if [ ! -f dl/nghttp2-${NGHTTP2}.tar.gz ]; then
+      (cd dl && curl -O -L https://github.com/nghttp2/nghttp2/releases/download/v${NGHTTP2}/nghttp2-${NGHTTP2}.tar.gz)
+    fi
+  - |
+    if [ ! -f dl/curl-${CURL}.tar.gz ]; then
+      (cd dl && curl -O -L https://curl.haxx.se/download/curl-${CURL}.tar.gz)
+    fi
+  - |
+    if [ ! -f dl/nginx-${NGINX_VERSION}.tar.gz ]; then
+      curl -o dl/nginx-${NGINX_VERSION}.tar.gz -L http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz;
+    fi
+  - |
+    if [ ! -f dl/test-nginx-${TESTNGINX_VER}.tar.gz ]; then
+      curl -o dl/test-nginx-${TESTNGINX_VER}.tar.gz -L "https://github.com/openresty/test-nginx/archive/${TESTNGINX_VER}.tar.gz";
+    fi
   - if [ ! -f dl/cpanm ]; then curl -o dl/cpanm https://cpanmin.us/; chmod +x dl/cpanm; fi
-  - cp dl/cpanm bin/cpanm
-  - tar -zxvf dl/nginx-${NGINX_VERSION}.tar.gz && mv nginx-${NGINX_VERSION} nginx
+  - |
+    if [ ! -e dl/nghttp2-${NGHTTP2} ]; then
+      (cd dl && tar -zxf nghttp2-${NGHTTP2}.tar.gz)
+    fi
+    (cd dl/nghttp2-${NGHTTP2} &&
+      ./configure --prefix=/usr --disable-threads &&
+      make && sudo make install)
+  - |
+    if [ ! -e dl/curl-${CURL} ]; then
+      (cd dl && tar -zxf curl-${CURL}.tar.gz)
+    fi
+    (cd dl/curl-${CURL} && ./configure --with-nghttp2 --prefix=/usr/local && make && sudo make install)
+  - sudo ldconfig
+  - sudo cp dl/cpanm /usr/local/bin/cpanm
+  - tar -zxf dl/nginx-${NGINX_VERSION}.tar.gz && mv nginx-${NGINX_VERSION} nginx
   - cpanm --notest --local-lib=perl5 local::lib && eval $(perl -I perl5/lib/perl5/ -Mlocal::lib)
-  - cpanm --notest dl/test-nginx-${TESTNGINX_VER}.tar.gz
-  - cpanm --notest Test::File
-  - cpanm --notest URI::Query
+  - |
+    if [ ! -f perl5/lib/perl5/Test/Nginx.pm ]; then
+      cpanm --notest dl/test-nginx-${TESTNGINX_VER}.tar.gz
+    fi
+  - |
+    if [ ! -f perl5/lib/perl5/Test/File.pm ]; then
+      cpanm --notest Test::File
+    fi
+
+install:
   - cd nginx
   - ./configure --with-http_v2_module --with-http_ssl_module --add-module=..
   - make

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,5 @@
+master (unreleased)
+* Added feature: http2 support. Thanks to Frankie Dintino.
 
 Version 2.2.1
  * Added feature: SHA-256 and SHA-512

--- a/t/error_handling.t
+++ b/t/error_handling.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+
+use File::Basename qw(dirname);
+
+use lib dirname(__FILE__) . "/lib";
+
+use Test::Nginx::Socket tests => 2;
+use Test::More;
+use Test::Nginx::UploadModule;
+
+no_long_string();
+no_shuffle();
+run_tests();
+
+__DATA__
+=== TEST 1: invalid content-range
+--- config
+location /upload/ {
+    upload_pass @upstream;
+    upload_resumable on;
+    upload_set_form_field "upload_tmp_path" "$upload_tmp_path";
+    upload_cleanup 400 404 499 500-505;
+}
+--- more_headers
+X-Content-Range: bytes 0-3/4
+X-Progress-ID: 0000000001
+Session-ID: 0000000001
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"\r
+--- request eval
+qq{POST /upload/
+testing}
+--- error_code: 416
+--- extra_tests eval
+use Test::File qw(file_not_exists_ok);
+sub {
+    my $block = shift;
+    file_not_exists_ok(
+        "${ENV{TEST_NGINX_UPLOAD_PATH}}/store/1/0000000001", $block->name . '- tmp file deleted');
+}

--- a/t/http2.t
+++ b/t/http2.t
@@ -1,0 +1,129 @@
+use strict;
+use warnings;
+
+use File::Basename qw(dirname);
+use lib dirname(__FILE__) . "/lib";
+use Cwd qw(abs_path);
+
+use Test::Nginx::Socket tests => 11;
+use Test::Nginx::UploadModule;
+
+$ENV{TEST_DIR} = abs_path(dirname(__FILE__));
+
+
+our $config = <<'_EOC_';
+location = /upload/ {
+    upload_pass @upstream;
+    upload_resumable on;
+
+    upload_set_form_field upload_file_name $upload_file_name;
+    upload_set_form_field upload_file_number $upload_file_number;
+    upload_set_form_field "upload_field_name" "$upload_field_name";
+    upload_set_form_field "upload_content_type" "$upload_content_type";
+    upload_set_form_field "upload_tmp_path" "$upload_tmp_path";
+    upload_set_form_field "upload_content_range" "$upload_content_range";
+    upload_aggregate_form_field "upload_file_size" "$upload_file_size";
+    upload_max_file_size 0;
+    upload_pass_args on;
+    upload_cleanup 400 404 499 500-505;
+}
+_EOC_
+
+no_long_string();
+no_shuffle();
+run_tests();
+
+__DATA__
+=== TEST 1: http2 simple upload
+--- config eval: $::config
+--- http2
+--- skip_nginx
+3: < 1.10.0
+--- more_headers
+X-Content-Range: bytes 0-3/4
+Session-ID: 0000000001
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"
+--- request eval
+qq{POST /upload/
+test}
+--- error_code: 200
+--- response_body eval
+qq{upload_content_range = bytes 0-3/4
+upload_content_type = text/plain
+upload_field_name = file
+upload_file_name = test.txt
+upload_file_number = 1
+upload_file_size = 4
+upload_tmp_path = $ENV{TEST_NGINX_UPLOAD_PATH}/store/1/0000000001
+}
+--- upload_file eval
+"test"
+
+=== TEST 2: http2 multiple chunk uploads
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- http2
+--- skip_nginx
+3: < 1.10.0
+--- more_headers eval
+[qq{X-Content-Range: bytes 0-1/4
+Session-ID: 0000000002
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"},
+qq{X-Content-Range: bytes 2-3/4
+Session-ID: 0000000002
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"}]
+--- request eval
+[["POST /upload/\r\n",
+"te"],
+["POST /upload/\r\n",
+"st"]]
+--- error_code eval
+[201, 200]
+--- response_body eval
+["0-1/4", qq{upload_content_range = bytes 2-3/4
+upload_content_type = text/plain
+upload_field_name = file
+upload_file_name = test.txt
+upload_file_number = 1
+upload_file_size = 4
+upload_tmp_path = $ENV{TEST_NGINX_UPLOAD_PATH}/store/2/0000000002
+}]
+--- upload_file eval
+"test"
+
+=== Test 3: http2 large multiple chunk uploads
+--- http_config eval: $::http_config
+--- skip_nginx
+5: < 1.10.0
+--- http2
+--- config eval: $::config
+--- more_headers eval
+[qq{X-Content-Range: bytes 0-131071/262144
+Session-ID: 0000000003
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"},
+qq{X-Content-Range: bytes 131072-262143/262144
+Session-ID: 0000000003
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"}]
+--- request eval
+[["POST /upload/\r\n",
+"@" . $ENV{TEST_NGINX_UPLOAD_FILE}],
+["POST /upload/\r\n",
+"@" . $ENV{TEST_NGINX_UPLOAD_FILE}]]
+--- error_code eval
+[201, 200]
+--- response_body eval
+["0-131071/262144", qq{upload_content_range = bytes 131072-262143/262144
+upload_content_type = text/plain
+upload_field_name = file
+upload_file_name = test.txt
+upload_file_number = 1
+upload_file_size = 262144
+upload_tmp_path = ${ENV{TEST_NGINX_UPLOAD_PATH}}/store/3/0000000003
+}]
+--- upload_file_like eval
+qr/^(??{'x' x 262144})$/

--- a/t/lib/Test/Nginx/UploadModule.pm
+++ b/t/lib/Test/Nginx/UploadModule.pm
@@ -5,6 +5,7 @@ use warnings;
 
 my $PORT = $ENV{TEST_NGINX_UPSTREAM_PORT} ||= 12345;
 $ENV{TEST_NGINX_UPLOAD_PATH} ||= '/tmp/upload';
+$ENV{TEST_NGINX_UPLOAD_FILE} = $ENV{TEST_NGINX_UPLOAD_PATH} . "/test_data.txt";
 
 
 use base 'Exporter';
@@ -32,6 +33,9 @@ sub make_upload_paths {
     for (my $i = 0; $i < 10; $i++) {
         mkpath("${ENV{TEST_NGINX_UPLOAD_PATH}}/store/$i");
     }
+    open(my $fh, ">", $ENV{TEST_NGINX_UPLOAD_FILE});
+    print $fh ('x' x 131072);
+    close($fh);
 }
 
 add_cleanup_handler(sub {

--- a/t/lib/Test/Nginx/UploadModule.pm
+++ b/t/lib/Test/Nginx/UploadModule.pm
@@ -1,0 +1,155 @@
+package Test::Nginx::UploadModule;
+use v5.10.1;
+use strict;
+use warnings;
+
+my $PORT = $ENV{TEST_NGINX_UPSTREAM_PORT} ||= 12345;
+$ENV{TEST_NGINX_UPLOAD_PATH} ||= '/tmp/upload';
+
+
+use base 'Exporter';
+
+use Test::Nginx::Socket;
+use Test::Nginx::Util qw($RunTestHelper);
+use Test::File qw(file_contains_like);
+use Test::More;
+
+use File::Path qw(rmtree mkpath);
+use Test::Nginx::UploadModule::TestServer;
+
+
+my ($server_pid, $server);
+
+sub kill_tcp_server() {
+    $server->shutdown if defined $server;
+    undef $server;
+    kill INT => $server_pid if defined $server_pid;
+    undef $server_pid;
+}
+
+sub make_upload_paths {
+    mkpath("${ENV{TEST_NGINX_UPLOAD_PATH}}/stats");
+    for (my $i = 0; $i < 10; $i++) {
+        mkpath("${ENV{TEST_NGINX_UPLOAD_PATH}}/store/$i");
+    }
+}
+
+add_cleanup_handler(sub {
+    kill_tcp_server();
+    rmtree($ENV{TEST_NGINX_UPLOAD_PATH});
+});
+
+my $OldRunTestHelper = $RunTestHelper;
+
+my @ResponseChecks = ();
+
+my $old_check_response_headers = \&Test::Nginx::Socket::check_response_headers;
+
+sub new_check_response_headers ($$$$$) {
+    my ($block, $res, $raw_headers, $dry_run, $req_idx, $need_array) = @_;
+    $old_check_response_headers->(@_);
+    if (!$dry_run) {
+        for my $check (@ResponseChecks) {
+            $check->(@_);
+        }
+    }
+}
+
+$RunTestHelper = sub ($$) {
+    if (defined $server) {
+        $OldRunTestHelper->(@_);
+    } else {
+        defined (my $pid = fork()) or bail_out "Can't fork: $!";
+        if ($pid == 0) {
+            $Test::Nginx::Util::InSubprocess = 1;
+            if (!defined $server) {
+                $server = Test::Nginx::UploadModule::TestServer->new({port=>$PORT});
+                $server->run();
+                exit 0;
+            }
+        } else {
+            $server_pid = $pid;
+            no warnings qw(redefine);
+            Test::Nginx::UploadModule::TestServer::wait_for_port($PORT, \&bail_out);
+            *Test::Nginx::Socket::check_response_headers = \&new_check_response_headers;
+
+            $OldRunTestHelper->(@_);
+
+            *Test::Nginx::Socket::check_response_headers = &$old_check_response_headers;
+
+            kill_tcp_server();
+        }
+    }
+};
+
+my $default_http_config = <<'_EOC_';
+upstream upload_upstream_server {
+    server 127.0.0.1:$TEST_NGINX_UPSTREAM_PORT;
+}
+
+log_format custom '$remote_addr - $remote_user [$time_local] '
+                    '"$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent" $request_time';
+_EOC_
+
+
+my $default_config = <<'_EOC_';
+location @upstream {
+    internal;
+    proxy_pass http://upload_upstream_server;
+}
+upload_store $TEST_NGINX_UPLOAD_PATH/store 1;
+upload_state_store $TEST_NGINX_UPLOAD_PATH/stats;
+
+access_log $TEST_NGINX_SERVER_ROOT/logs/access.log custom;
+_EOC_
+
+# Set default configs, create upload directories, and add extra_tests blocks to @ResponseChecks
+add_block_preprocessor(sub {
+    my $block = shift;
+
+    make_upload_paths();
+
+    if (!defined $block->http_config) {
+        $block->set_value('http_config', $default_http_config);
+    } else {
+        $block->set_value('http_config', $default_http_config . $block->http_config);
+    }
+    if (defined $block->config) {
+        $block->set_value('config', $default_config . $block->config);
+    }
+    if (defined $block->extra_tests) {
+        if (ref $block->extra_tests ne 'CODE') {
+            bail_out('extra_tests should be a subroutine, instead found ' . $block->extra_tests);
+        }
+
+        push(@ResponseChecks, $block->extra_tests);
+    }
+});
+
+# Add 'upload_file_like' block check
+add_response_body_check(sub {
+    my ($block, $body, $req_idx, $repeated_req_idx, $dry_run) = @_;
+
+    if ($dry_run) {
+        return;
+    }
+
+    my $num_requests = (ref $block->request eq 'ARRAY') ? scalar @{$block->request} : 1;
+    my $final_request = ($req_idx == ($num_requests - 1));
+    if ($final_request && defined $block->upload_file_like) {
+        my $ref_type = (ref $block->upload_file_like);
+        if (ref $block->upload_file_like ne 'Regexp') {
+            bail_out("upload_file_like block must be a regex pattern");
+        }
+        my $test_name = $block->name . " - upload file check";
+        if ($body =~ /upload_tmp_path = ([^\n]+)$/) {
+            file_contains_like($1, $block->upload_file_like, $test_name);
+        } else {
+            bail_out("upload_tmp_path information not found in response");
+        }
+    }
+    return $block;
+});
+
+1;

--- a/t/lib/Test/Nginx/UploadModule/TestServer.pm
+++ b/t/lib/Test/Nginx/UploadModule/TestServer.pm
@@ -1,0 +1,238 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+package File;
+{
+    sub new {
+        my ($class, $opts) = @_;
+        return bless {%$opts}, $class;
+    }
+}
+
+package Test::Nginx::UploadModule::TestServer;
+{
+use HTTP::Daemon ();
+use POSIX 'WNOHANG';
+use IO::Socket;
+use IO::Select;
+
+use base 'Exporter';
+
+our @EXPORT = qw(wait_for_port);
+our @EXPORT_OK = qw(wait_for_port);
+
+local $| = 1;
+
+sub new {
+    my ($class, $opts) = @_;
+    my $port = $opts->{port} || 12345;
+    my $self = {
+        opts => {
+            port => $port,
+        },
+    };
+    $self->{sock} = HTTP::Daemon->new(
+        LocalAddr => 'localhost',
+        LocalPort => $self->{opts}->{port},
+        ReuseAddr => 1
+    ) || die("Could not open socket on port $port: $!");
+
+    return bless $self, $class;
+}
+
+sub AUTOLOAD {
+    my $self = shift;
+    (my $attr = (our $AUTOLOAD)) =~ s/^.*::([^:]+)$/$1/;
+    if (@_) {
+        $self->{$attr} = shift;
+    } else {
+        return $self->{$attr};
+    }
+}
+
+
+sub trim {
+    my $val = shift;
+    if (defined $val) {
+        $val =~ s|^\s+||s;
+        $val =~ s|\s+$||s;
+    }
+    return $val;
+}
+
+sub strip_quotes {
+    my $s = shift;
+    return ($s =~ /^"(.*?)"$/) ? $1 : $s;
+}
+
+sub process_multipart_chunk {
+    my ($self, $value, $content_disposition) = @_;
+    my %kv;
+    if ($content_disposition) {
+        (my $disposition = $content_disposition) =~ s/^\s*?form-data\s*?;\s*?(?=\S)//g;
+        my @keyvals = map { /^(.*?)=(.*?)$/ && [lc($1), strip_quotes($2)] }
+                      map { trim($_) }
+                      split(';', $disposition);
+        %kv = map {@$_} @keyvals;
+    }
+    my $kv = \%kv;
+    if ($kv->{filename}) {
+        $value = File->new({filename => $kv->{filename}, contents => $value});
+    }
+    return [$kv->{name}, $value];
+}
+
+sub process_multipart {
+    my ($self, $content, $boundary) = @_;
+    my $data = {};
+    my $chunk_split = qr/^(.+?)\r\n\r\n(.+)$/s;
+    my $strip_dashes = qr/(\r\n)?\-+$/;
+    my $chunks = [];
+    my @chunks = grep { $_ } map { s/(\r\n)?\-+$//s; s/^\-+\s+$//s; $_ }
+                 split(/$boundary/, $content);
+    my %data = ();
+    for my $chunk (@chunks) {
+        my $chunk_data = {headers => {}, body => ''};
+        while ($chunk =~ /([\w\-]+)\:\s*(.+?)(?=\r\n)/pgs) {
+            $chunk_data->{headers}->{lc $1} = $2;
+            ($chunk_data->{value} = $') =~ s/^\r\n\r\n//g;
+        }
+        my $content_disposition = $chunk_data->{headers}->{'content-disposition'};
+        my ($k, $v) = @{$self->process_multipart_chunk($chunk_data->{value}, $content_disposition)};
+        $data->{$k} = $v;
+    }
+    return $data;
+}
+
+sub process_body {
+    my ($self, $client, $req) = @_;
+    my $content = $req->content;
+    my $content_type = $req->header('Content-Type');
+    my $data = {};
+    if ($content_type) {
+        if ($content_type =~ /multipart\/form\-data; boundary=(.+?)$/i) {
+            my $boundary = quotemeta($1);
+            return $self->process_multipart($content, $boundary);
+        }
+    }
+    my $ct_disp = $req->header('Content-Disposition');
+    if ($ct_disp) {
+        my ($k, $v) = @{$self->process_multipart_chunk($content, $ct_disp)};
+        $data->{$k} = $v;
+    }
+    return $data;
+}
+
+sub shutdown {
+    my $self = shift;
+    if (!defined $self->{sock}) {
+        exit 0;
+    }
+    $self->sock->close;
+    kill INT => $self->{forkpid} if defined $self->{forkpid};
+    undef $self->{sock};
+    exit 0;
+}
+
+sub handle_requests {
+    my ($self, $client) = @_;
+    while (my $req = $client->get_request()) {
+        my $response = HTTP::Response->new(200, 'OK');
+        $response->header('Content-Type' => 'text/html');
+
+        if ($req->uri->path eq '/shutdown/') {
+            $response->content("");
+            $client->send_response($response);
+            $client->close;
+            $self->sock->close;
+            undef $client;
+            $_[2] = 1;
+            exit 0;
+        }
+        my $data = $self->process_body($client, $req);
+        my %headers = $req->headers->flatten;
+        my @headers = ();
+        for my $k (sort keys %headers) {
+            my $v = $headers{$k};
+            push(@headers, "$k: $v");
+        }
+        my @fields = ();
+        for my $k (sort keys %$data) {
+            my $v = $data->{$k};
+            if ($v->isa('File')) {
+                my $filename = $v->{filename};
+                $k .= "(${filename})";
+                $v = $v->{contents};
+            }
+            push(@fields, "$k = $v");
+        }
+        my $response_str = join("\n", @fields) . "\n";
+        $response->content($response_str);
+        $client->send_response($response);
+    }
+}
+
+sub run {
+    my $self = shift;
+    while ((defined $self->{sock}) && (my $client = $self->sock->accept)) {
+        defined (my $pid = fork()) or die("Can't fork: $!");
+        if ($pid == 0) {
+            $client->close;
+            $self->sock->close;
+            next;
+        }
+        my $retval = 0;
+        $self->handle_requests($client, $retval);
+        $client->close;
+        if ($retval == 1) {
+            $client->close;
+            $self->sock->close;
+            undef $client;
+            exit 0;
+        }
+    }
+    if (defined $self->sock) {
+        $self->sock->close;
+    }
+}
+
+sub wait_for_port {
+    my ($port, $errhandler) = @_;
+    if (!defined $errhandler) {
+        $errhandler = \&die;
+    }
+    my $sock;
+    eval {
+        local $SIG{ALRM} = sub { die('timeout'); };
+        alarm(1);
+        while (1) {
+            $sock = IO::Socket::INET->new(PeerHost=>'127.0.0.1', PeerPort=>$port, Timeout=>1);
+            last if $sock;
+            select(undef, undef, undef, 0.1);
+        }
+        alarm(0);
+    };
+    if ($@ eq 'timeout' || !$sock) {
+        $errhandler->("Connecting to test server timed out");
+    } elsif ($@) {
+        alarm(0);
+        $errhandler->($@);
+    } elsif ($sock) {
+        $sock->close;
+    }
+}
+
+
+local $SIG{CHLD} = sub {
+    while ((my $child = waitpid(-1, WNOHANG )) > 0) {}
+};
+
+}
+
+if (!caller) {
+    my $server = __PACKAGE__->new();
+    $server->run();
+}
+
+1;

--- a/t/upload.t
+++ b/t/upload.t
@@ -1,0 +1,158 @@
+use strict;
+use warnings;
+
+use File::Basename qw(dirname);
+
+use lib dirname(__FILE__) . "/lib";
+
+use Test::Nginx::Socket tests => 22;
+use Test::Nginx::UploadModule;
+
+
+our $config = <<'_EOC_';
+location = /upload/ {
+    upload_pass @upstream;
+    upload_resumable on;
+
+    upload_set_form_field upload_file_name $upload_file_name;
+    upload_set_form_field upload_file_number $upload_file_number;
+    upload_set_form_field "upload_field_name" "$upload_field_name";
+    upload_set_form_field "upload_content_type" "$upload_content_type";
+    upload_set_form_field "upload_tmp_path" "$upload_tmp_path";
+    upload_set_form_field "upload_content_range" "$upload_content_range";
+    upload_aggregate_form_field "upload_file_size" "$upload_file_size";
+    upload_max_file_size 0;
+    upload_pass_args on;
+    upload_cleanup 400 404 499 500-505;
+}
+_EOC_
+
+no_long_string();
+no_shuffle();
+run_tests();
+
+__DATA__
+=== TEST 1: single chunk upload
+--- config eval: $::config
+--- more_headers
+X-Content-Range: bytes 0-3/4
+Session-ID: 0000000001
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"
+--- request eval
+qq{POST /upload/
+test}
+--- error_code: 200
+--- response_body eval
+qq{upload_content_range = bytes 0-3/4
+upload_content_type = text/plain
+upload_field_name = file
+upload_file_name = test.txt
+upload_file_number = 1
+upload_file_size = 4
+upload_tmp_path = ${ENV{TEST_NGINX_UPLOAD_PATH}}/store/1/0000000001
+}
+--- upload_file_like eval
+qr/^test$/
+
+=== TEST 2: multiple chunk uploads
+--- http_config eval: $::http_config
+--- config eval: $::config
+--- more_headers eval
+[qq{X-Content-Range: bytes 0-1/4
+Session-ID: 0000000002
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"},
+qq{X-Content-Range: bytes 2-3/4
+Session-ID: 0000000002
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"}]
+--- request eval
+[["POST /upload/\r\n",
+"te"],
+["POST /upload/\r\n",
+"st"]]
+--- error_code eval
+[201, 200]
+--- response_body eval
+["0-1/4", qq{upload_content_range = bytes 2-3/4
+upload_content_type = text/plain
+upload_field_name = file
+upload_file_name = test.txt
+upload_file_number = 1
+upload_file_size = 4
+upload_tmp_path = ${ENV{TEST_NGINX_UPLOAD_PATH}}/store/2/0000000002
+}]
+--- upload_file_like eval
+qr/^test$/
+
+=== Test 3: large multiple chunk uploads
+--- config eval: $::config
+--- more_headers eval
+[qq{X-Content-Range: bytes 0-131071/262144
+Session-ID: 0000000003
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"},
+qq{X-Content-Range: bytes 131072-262143/262144
+Session-ID: 0000000003
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"}]
+--- request eval
+[["POST /upload/\r\n",
+"x" x 131072],
+["POST /upload/\r\n",
+"x" x 131072]]
+--- error_code eval
+[201, 200]
+--- response_body eval
+["0-131071/262144", qq{upload_content_range = bytes 131072-262143/262144
+upload_content_type = text/plain
+upload_field_name = file
+upload_file_name = test.txt
+upload_file_number = 1
+upload_file_size = 262144
+upload_tmp_path = ${ENV{TEST_NGINX_UPLOAD_PATH}}/store/3/0000000003
+}]
+--- upload_file_like eval
+qr/^(??{'x' x 262144})$/
+
+=== Test 4: upload_limit_rate
+--- config
+location = /upload/ {
+    upload_pass @upstream;
+    upload_resumable on;
+    upload_aggregate_form_field "upload_file_size" "$upload_file_size";
+    upload_set_form_field "upload_tmp_path" "$upload_tmp_path";
+    upload_max_file_size 0;
+    upload_pass_args on;
+    upload_cleanup 400 404 499 500-505;
+    upload_limit_rate 32768;
+}
+--- timeout: 5
+--- more_headers eval
+[qq{X-Content-Range: bytes 0-131071/262144
+Session-ID: 0000000004
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"},
+qq{X-Content-Range: bytes 131072-262143/262144
+Session-ID: 0000000004
+Content-Type: text/plain
+Content-Disposition: form-data; name="file"; filename="test.txt"}]
+--- request eval
+[["POST /upload/\r\n",
+"x" x 131072],
+["POST /upload/\r\n",
+"x" x 131072]]
+--- error_code eval
+[201, 200]
+--- response_body eval
+["0-131071/262144", qq{upload_file_size = 262144
+upload_tmp_path = ${ENV{TEST_NGINX_UPLOAD_PATH}}/store/4/0000000004
+}]
+--- upload_file_like eval
+qr/^(??{'x' x 262144})$/
+--- access_log eval
+# should have taken 4 seconds, with 1 second possible error
+# (Test::Nginx::UploadModule::http_config adds request time to the end of
+# the access log)
+[qr/[34]\.\d\d\d$/, qr/[34]\.\d\d\d$/]


### PR DESCRIPTION
This PR adds full support for http2 (originally it was lacking `upload_limit_rate` support, but I have since added that). I wrote some tests using [Test::Nginx](https://github.com/openresty/test-nginx) to make sure I didn't introduce any regressions and to verify that the new http2 support works.

I added a `.travis.yml` file to demonstrate how to run the tests (the build results can be seen [here](https://travis-ci.org/theatlantic/nginx-upload-module/builds/343536315)). The tests need the `Test::Nginx` module installed from source as well as `Test::File`, and the http2 tests need curl compiled with nghttp2.

A few notes on the implementation:

In nginx 1.7.11, support was added for [disabling request body buffering](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering). In nginx 1.10 http2 was updated to support unbuffered requests (hence why I disable the http2 tests for nginx 1.9). If we set the `r->request_body_no_buffering` flag and add a `read_event_handler` then it is possible to perform the usual function of this module without having to recreate nginx core's default request handler. I was more-or-less forced to do this because nearly all of the http2 request handling functions are statically declared, so I would have had to copy-paste over a thousand lines of code to make it work.

But there's nothing http2-specific about setting `r->request_body_no_buffering = 1` and using a read event handler.  If support for nginx < 1.7.11 were dropped then you could use this for regular http requests as well. That would allow you to delete `ngx_http_read_upload_client_request_body` and the other request body handler functions—a total of 430 lines. Still, that seemed like too-bold a refactor for this PR, so I instead did this inside an http2 conditional. But you may want to consider it, as it will help make this module more future-compatible with nginx. I'd be happy to open that as PR for you as well.