### PR TITLE
Fixed upload_aggregate_form_field 'upload_file_md5' calculation

### DIFF
--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -2445,7 +2445,7 @@ ngx_http_upload_md5_variable(ngx_http_request_t *r,
 
     u = ngx_http_get_module_ctx(r, ngx_http_upload_module);
 
-    if(u->sha1_ctx == NULL || u->partial_content) {
+    if(u->md5_ctx == NULL || u->partial_content) {
         v->not_found = 1;
         return NGX_OK;
     }


### PR DESCRIPTION
Fixed check from sha1_ctx to md5_ctx in ngx_http_upload_md5_variable() for correct  'upload_file_md5' calculation.