### PR TITLE
Fix issue where upload headers were only added to final request

### DIFF
--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -1596,6 +1596,11 @@ static ngx_int_t ngx_http_upload_start_handler(ngx_http_upload_ctx_t *u) { /* {{
             u->discard_data = 1;
     }
 
+
+    if(ngx_http_upload_add_headers(r, ulcf) != NGX_OK) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
     return NGX_OK;
 
 cleanup_file:
@@ -1686,10 +1691,6 @@ static void ngx_http_upload_finish_handler(ngx_http_upload_ctx_t *u) { /* {{{ */
             , &u->file_name
             , &u->output_file.name
             );
-
-        if (ngx_http_upload_add_headers(r, ulcf) != NGX_OK) {
-            goto rollback;
-        }
 
         if(ulcf->aggregate_field_templates) {
             af = ulcf->aggregate_field_templates->elts;


### PR DESCRIPTION
fixes #124

@vkholodkov The reason I moved it from its original location was so it would have access to the upload variables (so that those could be included in the headers) but I mistakenly put it in the finish handler. I think the function actually needs to move to the end of ngx_http_upload_start_handler if we want it to be able to interpolate the `$upload_` variables.