### PR TITLE
Handle quotes problems in Content-Type and Content-Disposition

### DIFF
--- a/t/lib/Test/Nginx/UploadModule/TestServer.pm
+++ b/t/lib/Test/Nginx/UploadModule/TestServer.pm
@@ -111,7 +111,7 @@ sub process_body {
     my $content_type = $req->header('Content-Type');
     my $data = {};
     if ($content_type) {
-        if ($content_type =~ /multipart\/form\-data; boundary=(.+?)$/i) {
+        if ($content_type =~ /multipart\/form\-data; boundary="?(.+?)"?$/i) {
             my $boundary = quotemeta($1);
             return $self->process_multipart($content, $boundary);
         }


### PR DESCRIPTION
Fixes https://github.com/fdintino/nginx-upload-module/issues/50
Supersedes https://github.com/fdintino/nginx-upload-module/pull/51
Based on discussions in https://github.com/fdintino/nginx-upload-module/pull/66

This Pull Request addresses two problem related to the presence or absence of quotes in a `multipart/form-data` upload:
-  When performing a multipart upload, the separator between each data is given with the `boundary` field in the `Content-Type` header:
    
    ```
    Content-Type: multipart/form-data; boundary=MyBoundary
    ```
    According to [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1.1), using quotes in `Content-Type`'s boundary is valid:
    
    ```
    Content-Type: multipart/form-data; boundary="MyBoundary"
    ```
    For example .NET HttpClient uses them by default.
    However when receiving quoted boundaries, `nginx-upload-module` currently fails to read the content of the request body, and forwards an empty request to the upstream.
    This Pull Request now accepts quoted boundaries `boundary="MyBoundary"` syntax.
- In the same style, the `name` and `filename` of each file sent in the multipart request is provided in the `Content-Disposition` of each data:

    ```
    Content-Disposition: form-data; name="file"; filename="example.txt"
    ```
    However, using quotes for `name` and `filename` is not required ([RFC 2388](https://tools.ietf.org/html/rfc2388#section-3), [RFC 6266](https://tools.ietf.org/html/rfc6266#section-4.1)), and some libraries do indeed send `name` and `filename` values without quotes:

    ```
    Content-Disposition: form-data; name=file; filename=example.txt
    ```

    `nginx-upload-module` currently returns an errors when this occurs.
    This Pull Request adds supports for unquoted `name` and `filename` in `Content-Disposition`.

I've added two new test cases in `t/upload.t`:
- One to test a regular multipart file upload (which was not tested until now)
- One to test a multipart file upload with the above corner cases: quotes for the boundary in Content-Type, and missing quotes for the `name` and `filename` in Content-Disposition.