### PR TITLE
fixes upload_pass_form_field https://github.com/fdintino/nginx-upload…

### DIFF
--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -1573,7 +1573,7 @@ static ngx_int_t ngx_http_upload_start_handler(ngx_http_upload_ctx_t *u) { /* {{
                 /*
                  * If at least one filter succeeds, we pass the field
                  */
-                if(rc == 0)
+                if(rc >= 0)
                     pass_field = 1;
 #else
                 if(ngx_strncmp(f[i].text.data, u->field_name.data, u->field_name.len) == 0)


### PR DESCRIPTION
This fixes https://github.com/fdintino/nginx-upload-module/issues/150  Namely, it makes module to pass fields matching `upload_pass_form_field` regex to `upload_pass` location.
